### PR TITLE
docs: README を整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # typescript-template
+
+TypeScript + Bun + Biome を使った Claude Code 向けモノレポテンプレート。
+
+## ツールスタック
+
+| 用途 | ツール |
+|------|--------|
+| ランタイム | Bun |
+| バックエンド | Hono |
+| フロントエンド | Vite + React |
+| リンター/フォーマッター | Biome |
+| テスト | bun test |
+| Git フック | Husky + lint-staged |
+
+## セットアップ
+
+```bash
+# 依存をインストール
+bun install
+
+# プロジェクトをスキャフォールド（初回のみ）
+# Claude Code で以下を実行
+/init-project
+```
+
+## コマンド
+
+```bash
+make install      # 全パッケージの依存をインストール
+make lint         # biome check
+make format       # biome format
+make typecheck    # tsc --noEmit
+make test         # bun test
+make build        # ビルド
+make before-commit  # コミット前チェック（lint + typecheck + test + build）
+```
+
+## スキル
+
+| スキル | 説明 |
+|--------|------|
+| `/init-project` | packages/backend（Hono）と packages/frontend（Vite + React）をスキャフォールド |
+
+## ディレクトリ構成
+
+```
+.
+├── .claude/
+│   ├── settings.json       # Claude Code フック設定
+│   ├── scripts/            # フック実行スクリプト
+│   └── skills/             # カスタムスキル
+├── packages/
+│   ├── backend/            # /init-project で Hono サーバーを生成
+│   └── frontend/           # /init-project で Vite + React を生成
+├── biome.json              # リンター/フォーマッター設定
+├── CLAUDE.md               # AI エージェント向け開発ガイドライン
+└── Makefile
+```
+
+## 開発ガイドライン
+
+[CLAUDE.md](./CLAUDE.md) を参照。


### PR DESCRIPTION
## 概要

タイトル一行だけだった README を実用的な内容に更新。

## 変更内容

- ツールスタック一覧
- セットアップ手順（`/init-project` スキルの案内含む）
- make コマンド一覧
- ディレクトリ構成
- CLAUDE.md へのリンク

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Significantly expanded README with detailed setup instructions for the TypeScript monorepo template, comprehensive documentation of the tool stack (Bun with Hono backend, Vite+React frontend, Biome for linting and formatting), complete reference of available make commands (install, lint, format, typecheck, test, build), before-commit hook configuration details, and project directory structure guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->