### PR TITLE
fix: bun install に --safe-chain-skip-minimum-package-age フラグを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 
 .PHONY: install_ci
 install_ci:
-	bun install --frozen-lockfile
+	bun install --frozen-lockfile --safe-chain-skip-minimum-package-age
 
 .PHONY: build
 build:


### PR DESCRIPTION
## 修正

`SAFE_CHAIN_SKIP_MINIMUM_PACKAGE_AGE` 環境変数ではなく、`bun install` のコマンドラインフラグとして渡す必要があった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)