### PR TITLE
docs(init-project): vitest ウォッチモード回避ルールを追加

### DIFF
--- a/.claude/skills/init-project/SKILL.md
+++ b/.claude/skills/init-project/SKILL.md
@@ -13,6 +13,28 @@ description: プロジェクトを Bun + Hono（バックエンド）+ Vite + Re
 - リンター/フォーマッター: Biome（ルートの `biome.json` を共有）
 - テスト: `bun test`
 
+## 重要なルール
+
+**`test` スクリプトは必ず終了するコマンドを使うこと。**
+ウォッチモードで起動するコマンドは CI やエージェントをブロックする。
+
+| NG（ウォッチモード） | OK（終了する） |
+|---------------------|----------------|
+| `vitest` | `vitest run` |
+| `vitest watch` | `vitest run` |
+| `jest --watch` | `jest --watchAll=false` |
+
+ウォッチ用途は別スクリプトとして切り出す。
+
+```json
+{
+  "test": "bun test",
+  "test:watch": "bun test --watch"
+}
+```
+
+このテンプレートでは `bun test` を標準として使用する。`vitest` を採用する場合は必ず `vitest run` を `test` スクリプトに使うこと。
+
 ---
 
 ## 手順 1: ユーザーに確認する
@@ -38,6 +60,7 @@ description: プロジェクトを Bun + Hono（バックエンド）+ Vite + Re
     "start": "bun run src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target bun",
     "test": "bun test",
+    "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",
     "typecheck": "tsc --noEmit"
   },
@@ -138,6 +161,7 @@ cargo install hurl
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "bun test",
+    "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",


### PR DESCRIPTION
## 概要

- `test` スクリプトにはウォッチモードにならない終了するコマンドを使うルールを明文化
- vitest を採用した場合は `vitest run` を使うよう NG/OK 対比表で説明
- `test:watch` を別スクリプトとして切り出すパターンを例示
- backend/frontend テンプレートに `test:watch` スクリプトを追加

## 背景

vitest はデフォルトでウォッチモードになるため、CI やエージェントがブロックされる。
init-project スキルで scaffold したプロジェクトがこの問題を避けられるようルールを追加。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)