### PR TITLE
feat: architecture harness invariants と /follow-up スキルでスコープクリープを抑える

### DIFF
--- a/.claude/scripts/follow-up-reminder.sh
+++ b/.claude/scripts/follow-up-reminder.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SessionStart hook: 未処理フォローアップが残っていれば件数を Claude に通知する。
+# 出力: 件数 > 0 のとき systemMessage を 1 行 JSON で stdout に出す。
+# 件数 = 0 または state ファイル無しなら無音。
+
+set -euo pipefail
+
+STATE_FILE=".claude/state/follow-ups.jsonl"
+
+if [ ! -f "$STATE_FILE" ]; then
+  exit 0
+fi
+
+# `"status":"open"` を含む行を数える (jq 無しで動く軽量実装)
+count=$(grep -c '"status":"open"' "$STATE_FILE" 2>/dev/null || true)
+
+if [ -z "$count" ] || [ "$count" -eq 0 ] 2>/dev/null; then
+  exit 0
+fi
+
+# JSON 1 行を出す。シェル経由で出すため変数のエスケープに注意 (count は数値だけ)
+printf '{"systemMessage": "未処理フォローアップが %s 件あります。/follow-up で一覧確認、別 PR で順次解消してください。"}\n' "$count"

--- a/.claude/scripts/stop-gate-reminder.sh
+++ b/.claude/scripts/stop-gate-reminder.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Stop hook: TS 系の変更がある状態で停止したら、ゲートとフォローアップ運用を Claude に思い出させる。
+# 出力: 変更があれば systemMessage を 1 行 JSON で stdout に出す。なければ無音。
+
+set -euo pipefail
+
+# git で TS/TSX 変更があるか確認
+if ! git diff --name-only HEAD 2>/dev/null | grep -qE '\.(ts|tsx)$'; then
+  exit 0
+fi
+
+# 1 行 JSON。改行を含めない。
+printf '{"systemMessage": "TS 変更検出。コミット前ゲートを順に: (1) /architecture-harness で invariant チェック、(2) make before-commit (lint/typecheck/test/build)、(3) /review /security-review /simplify。scope 外の発見は /follow-up add で記録し別 PR に切ること。"}\n'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git diff --name-only HEAD 2>/dev/null | grep -qE '\\.(ts|tsx)$' && echo '{\"systemMessage\": \"TS ファイルが変更されています。nr lint && nr typecheck && nr test && nr build が全て通過していることを確認してください。\"}' || true"
+            "command": "bash .claude/scripts/stop-gate-reminder.sh"
           }
         ]
       }
@@ -73,6 +73,10 @@
           {
             "type": "command",
             "command": "[ ! -f Plan.md ] && echo '{\"systemMessage\": \"Plan.md が見つかりません。実装を始める前に Plan.md を作成してください（CLAUDE.md を参照）。\"}' || true"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/follow-up-reminder.sh"
           }
         ]
       }

--- a/.claude/skills/architecture-harness/SKILL.md
+++ b/.claude/skills/architecture-harness/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: architecture-harness
+description: docs/architecture/harness.md の invariant を機械的に検証するスキル。引数なしで `--staged --fail-on=error` (PR 直前用)、`full` で全件スキャン、`why <RULE_ID>` で invariant の意図を harness.md から引いて表示。コミット直前 / Stop hook から呼ばれる前提。
+---
+
+# architecture-harness Skill
+
+`docs/architecture/harness.md` で定義された invariant を `scripts/architecture-harness.ts` で機械検証する。invariant の正本は `docs/architecture/harness.md`、本スキルはあくまで実行の入り口。
+
+## サブコマンド
+
+### 1. 引数なし — ステージ済の変更だけ厳密チェック (PR 直前用)
+
+```bash
+bun scripts/architecture-harness.ts --staged --fail-on=error
+```
+
+exit code 2 なら invariant 違反あり。markdown レポートが標準出力に出るので、違反箇所と invariant ID を確認してコードを修正する。**設定や invariant を緩める方向の修正は ADR が必要。**
+
+### 2. `full` — リポジトリ全体スキャン (リファクタ後の総点検用)
+
+```bash
+bun scripts/architecture-harness.ts --fail-on=warning
+```
+
+`--fail-on=warning` で warning 以上を拾う。新規 invariant を追加した直後や、大規模リファクタ後の総点検に使う。
+
+### 3. `why <RULE_ID>` — invariant の意図を表示
+
+`docs/architecture/harness.md` から該当 invariant のセクションを抜き出して表示する。レビュー中に「この invariant は何を守ってるんだっけ?」となったときに使う。
+
+```bash
+RULE_ID="$1"
+awk -v rule="$RULE_ID" '
+  $0 ~ "^- `" rule "`" {found=1; print; next}
+  found && /^- `INVARIANT_/ {found=0}
+  found {print}
+' docs/architecture/harness.md
+```
+
+## 違反時の標準フロー
+
+1. レポートで rule ID を確認
+2. `/architecture-harness why <RULE_ID>` で意図を再読
+3. **コードを修正** (invariant や設定を緩めない)
+4. 再度 `/architecture-harness` で違反 0 件を確認
+5. invariant が現実と合わなくなった場合は ADR を起こす (`docs/adr/NNNN-...md`)。本スキルで「緩める」判断はしない
+
+## ADR を起こすケース
+
+- ライブラリ更新で旧 invariant の前提が崩れた
+- 機能要件の変化で invariant の制約が過剰になった
+- 検出ロジックが false positive を量産している
+
+ADR テンプレート: `docs/adr/0000-template.md`
+
+## 関連
+
+- 検出器の本体: `scripts/architecture-harness.ts`
+- invariant 正本: `docs/architecture/harness.md`
+- フォローアップ管理: `/follow-up` スキル
+- PR 直前ゲートの順序: `CLAUDE.md` の「ハーネスとゲート」節

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: follow-up
+description: PR の主目的から外れた発見・改善・技術的負債を「フォローアップ」として記録、列挙、解消管理するスキル。スコープクリープを防ぎ、scope 外の課題を別 PR で確実に処理する仕組み。引数なしで起動すると未処理一覧、`add <title>` で追加、`resolve <id> <pr-url>` で解消記録、`list-pr-body` で PR 本文に貼る markdown を出力。
+---
+
+# follow-up Skill
+
+PR 作業中に scope 外の発見をしたら、その場で実装せずに本スキルで記録する。スコープクリープを防ぎ、見つけた課題は別 PR で処理することを徹底する。
+
+## ストレージ
+
+- 永続バックログ: `.claude/state/follow-ups.jsonl`
+  - JSON Lines 形式（1 行 = 1 エントリ）
+  - フィールド: `id` (ULID), `created_at` (ISO8601), `branch`, `title`, `description`, `severity` (low/medium/high), `status` (open/resolved), `resolved_pr` (URL or null), `resolved_at` (ISO8601 or null)
+- 初回利用時は `.claude/state/` ディレクトリと空のファイルを作る (`mkdir -p .claude/state && touch .claude/state/follow-ups.jsonl`)
+
+## サブコマンド
+
+### 1. 引数なし — 未処理フォローアップ一覧を表示
+
+```bash
+# 実装イメージ
+[ -f .claude/state/follow-ups.jsonl ] || { echo "（フォローアップなし）"; exit 0; }
+jq -c 'select(.status == "open")' .claude/state/follow-ups.jsonl | \
+  jq -r '"- [\(.severity)] \(.id) \(.title) (\(.created_at[0:10]), branch: \(.branch))"'
+```
+
+未処理が 0 件なら "（未処理フォローアップなし）" と返して終了。
+
+### 2. `add <title>` — フォローアップを追加
+
+ユーザー入力から `title` (必須) と `description` (任意・複数行可) を受け取り、ストレージに追記する。
+
+- `id` は ULID で発行 (`bunx ulid` または `python -c "import ulid; print(ulid.new())"` または `date +%s%N` の代替)
+- `branch` は `git rev-parse --abbrev-ref HEAD` で取得
+- `severity` はユーザー指定がなければ `medium`
+- 追記したら、現在の PR 本文に貼る markdown スニペットも出力:
+  ```markdown
+  ## Known follow-ups
+  - F-XXXXXX: <title> (`severity: medium`)
+  ```
+
+例:
+```bash
+mkdir -p .claude/state
+ID=$(bunx ulid 2>/dev/null || date +%s%N)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+jq -nc \
+  --arg id "$ID" \
+  --arg created_at "$NOW" \
+  --arg branch "$BRANCH" \
+  --arg title "$TITLE" \
+  --arg description "$DESCRIPTION" \
+  --arg severity "${SEVERITY:-medium}" \
+  '{id:$id, created_at:$created_at, branch:$branch, title:$title, description:$description, severity:$severity, status:"open", resolved_pr:null, resolved_at:null}' \
+  >> .claude/state/follow-ups.jsonl
+```
+
+### 3. `resolve <id> <pr-url>` — フォローアップを解消にマーク
+
+該当 `id` のエントリを `status: "resolved"`, `resolved_pr: "<url>"`, `resolved_at: "<now>"` で更新する。
+JSONL は append-only にしたい場合は新しい行で履歴を残す方式も可。シンプルに jq で書き換え:
+
+```bash
+TMP=$(mktemp)
+jq -c --arg id "$ID" --arg pr "$PR_URL" --arg now "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  'if .id == $id then .status = "resolved" | .resolved_pr = $pr | .resolved_at = $now else . end' \
+  .claude/state/follow-ups.jsonl > "$TMP"
+mv "$TMP" .claude/state/follow-ups.jsonl
+```
+
+### 4. `list-pr-body` — 現在のブランチ向け PR 本文ブロックを生成
+
+現在のブランチで作られた未処理フォローアップを集めて、PR の "Known follow-ups" 節に貼れる markdown を出力する。
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+echo "## Known follow-ups"
+echo ""
+jq -c --arg b "$BRANCH" 'select(.status == "open" and .branch == $b)' .claude/state/follow-ups.jsonl 2>/dev/null | \
+  jq -r '"- F-\(.id[-6:]): \(.title) (`severity: \(.severity)`)"'
+```
+
+何もなければ "（このブランチで記録されたフォローアップはなし）" と出す。
+
+### 5. `purge-resolved` — 解消済みエントリを別ファイルへアーカイブ
+
+`.claude/state/follow-ups.jsonl` から `status: resolved` を抜いて `.claude/state/follow-ups.archive.jsonl` に移す。バックログが肥大化したときの掃除用。
+
+## 運用ルール
+
+- フォローアップは **必ず別 PR** で処理する。同 PR で前倒し処理するのは「現在の PR が CI で詰まる原因になっている」場合のみ。
+- PR 作成時に `list-pr-body` を実行して PR 本文に貼る。
+- 別 PR で解消したら `resolve <id> <pr-url>` で記録する。
+- バックログが肥大化したら `purge-resolved` で整理する。
+
+## 例
+
+scope 外の旧コード発見:
+
+```
+ユーザー: /follow-up add "旧 sample-utils 削除"
+Claude: ID F-A1B2C3 で記録した。PR 本文に貼る markdown:
+        ## Known follow-ups
+        - F-A1B2C3: 旧 sample-utils 削除 (`severity: medium`)
+```
+
+別 PR で解消:
+
+```
+ユーザー: /follow-up resolve F-A1B2C3 https://github.com/foo/bar/pull/42
+Claude: F-A1B2C3 を resolved に更新した。
+```

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dist
 .pnp.*
 
 .DS_Store
+
+# Claude harness runtime state (per-developer; not committed)
+# 生成元: /follow-up スキル (詳細: .claude/skills/follow-up/SKILL.md)
+.claude/state/*.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,80 @@
-# Refer to [CLAUDE.md](./CLAUDE.md)
+# AGENTS.md
+
+AI エージェント (Claude Code, Codex 等) 向けの作業ガイド。`CLAUDE.md` を補完する。
+
+## セットアップ
+
+```bash
+make install      # 依存関係インストール（Bun）
+make dev          # 開発サーバ起動
+```
+
+## 品質ゲート (PR 作成前に必須、この順序で)
+
+```bash
+bun scripts/architecture-harness.ts --staged --fail-on=error
+make before-commit              # lint_text + lint + typecheck + test + build
+/review                         # コードレビュー
+/security-review                # セキュリティレビュー
+/simplify                       # 重複・品質・効率
+```
+
+**すべて通らない限りタスクは未完了。** 失敗したらコードを修正する（設定ファイルや invariant を変えない）。
+
+## 作業順序（厳守）
+
+1. **ドキュメント更新** — 関連する docs/、ADR、CLAUDE.md を先に更新する。
+2. **リファクタリング** — 既存の技術的負債を先に解消する。
+3. **機能追加** — 上 2 つが終わってから着手する。
+
+ハーネス invariant の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md)。`Codex` と `Claude Code` のどちらでも、この script を通らない変更は未完了として扱う。
+
+## フォローアップタスクの扱い
+
+PR 作業中に scope 外の発見をしたら、その場で実装しない。
+
+1. **`/follow-up add <タイトル>`** スキルで `.claude/state/follow-ups.jsonl` に記録する。
+2. TodoWrite/TaskCreate で `[フォローアップ]` プレフィックス付きタスクも作る。
+3. PR 作成時に **`/follow-up list-pr-body`** の出力を PR 本文の「Known follow-ups」節に貼る。
+4. 別 PR で処理する。解消したら **`/follow-up resolve <id> <pr-url>`** で記録。
+
+scope 外の修正を同 PR に混ぜることは「現在の PR が CI で詰まる原因になっている」場合のみ許可する。
+
+セッション開始時 (SessionStart hook) と作業終了時 (Stop hook) に、未処理フォローアップ件数とゲート確認を Claude に通知する仕組みが入っている (`.claude/scripts/{follow-up,stop-gate}-reminder.sh`)。
+
+## コマンド一覧
+
+| コマンド | 用途 |
+| --- | --- |
+| `ni` | 依存関係インストール |
+| `nr dev` | 開発サーバ起動 |
+| `nr test` | テスト実行 |
+| `nr typecheck` | TypeScript 型チェック |
+| `nr build` | プロダクションビルド |
+| `make before-commit` | 品質ゲート一括 |
+| `bun scripts/architecture-harness.ts` | invariant スキャン (全件) |
+| `bun scripts/architecture-harness.ts --staged --fail-on=error` | ステージ済変更のみ |
+
+## 制約 (破ったら即修正)
+
+- **`npx` 禁止** → `bunx` または `nlx` を使う (`INVARIANT_NO_NPX`)
+- **`rm` コマンド禁止** → `git rm` または手で削除依頼
+- **モックデータ・スタブ API 禁止** → Real DB / Real API を使う (`INVARIANT_NO_MOCK_DATA`)
+- **`it.only` / `describe.only` / `xit` / `xdescribe` 禁止** → コミット前に外す (`INVARIANT_NO_TEST_FOCUS`)
+- **設定ファイル (biome.json 等) の直接編集禁止** → コードを修正する
+- **テストタイトルは日本語 BDD スタイル**
+- **Conventional Commits**
+- **Issue は `#番号` 引用禁止** → フル URL か `Issue 番号` で記述
+
+## ADR
+
+設計判断は `docs/adr/NNNN-タイトル.md` に記録する。テンプレートは [`docs/adr/0000-template.md`](./docs/adr/0000-template.md)。
+
+- ADR は不変。変更は新しい ADR で Supersede する。
+- harness invariant の追加・緩和も ADR で残す。
+
+## ハーネスの拡張
+
+- 新しい invariant を追加するときは `docs/architecture/harness.md` に文章で書き、可能なら `scripts/architecture-harness.ts` の `RULES` / `REPO_CHECKS` に検出ロジックを足す。
+- 検出が困難な invariant はコードレビューで担保する旨を invariant 説明に書く。
+- invariant の緩和・廃止には ADR が必要。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,58 @@
 目的 / 制約 / タスク / 検証手順 / 進捗ログ / 振り返り（問題・根本原因・予防策）
 ```
 
-## 品質ゲート
+## ハーネスとゲート
 
-タスク完了前に全て Green にする。
+アーキテクチャ原則の正本は [`docs/architecture/harness.md`](./docs/architecture/harness.md) です。コード変更が invariant に違反する場合は、コードを直すのが第一手で、invariant 緩和は ADR で明示的に supersede します。
+
+### PR 作成前の必須ゲート（この順序で実行）
+
+```bash
+bun scripts/architecture-harness.ts --staged --fail-on=error   # 1. invariant 違反検出
+make before-commit                                              # 2. lint / typecheck / test / build
+/review                                                         # 3. コードレビュー
+/security-review                                                # 4. セキュリティレビュー
+/simplify                                                       # 5. 重複・品質・効率の最終チェック
+```
+
+すべて通るまで未完了。失敗したら原因を特定してコードを修正する（設定ファイルや invariant を変更しない）。
+
+### 作業順序
+
+新規機能を追加する前に、以下を先に実施する。
+
+1. **ドキュメント更新** — 変更に関連する `docs/`、ADR、`CLAUDE.md` を先に更新する。
+2. **リファクタリング** — 既存の技術的負債を先に解消する。
+3. **機能追加** — 上 2 つが終わってから着手する。
+
+## フォローアップタスクの扱い
+
+PR 作業中に scope 外の発見・改善・技術的負債を見つけたとき、その場で実装する誘惑がスコープクリープを生む。以下のルールで運用する。
+
+- その場で実装しない。**`/follow-up add <タイトル>`** で `.claude/state/follow-ups.jsonl` に記録する。
+- 同時に TodoWrite/TaskCreate で `[フォローアップ]` プレフィックス付きタスクも作る (今セッション内のリマインダー用)。
+- PR 作成時に **`/follow-up list-pr-body`** で出力される markdown を PR 本文の「Known follow-ups」節に貼る。
+- フォローアップは原則 **別 PR** で処理する。同 PR で前倒し処理するのは「現在の PR が CI 等で詰まる原因になっている」場合のみ許可。
+- 別 PR で解消したら **`/follow-up resolve <id> <pr-url>`** で記録する。
+
+セッション開始時に未処理フォローアップが残っていれば `.claude/scripts/follow-up-reminder.sh` (SessionStart hook) が件数を Claude に通知する。コミット直前の Stop hook (`.claude/scripts/stop-gate-reminder.sh`) もゲートとフォローアップの確認を促す。
+
+> 例: PR で SBT アダプタを直していたら旧 CDK スタックがデッドコードと判明 → `/follow-up add 旧 CDK 削除` で記録 → 同 PR では修正のみコミット → 別 PR で旧 CDK を消したら `/follow-up resolve <id> <pr-url>` で完了マーク。
+
+## ADR（Architecture Decision Records）
+
+設計判断は `docs/adr/` に ADR として記録する。
+
+- ファイル名: `NNNN-タイトル.md`（例: `0001-biome-を採用.md`）。
+- テンプレート: [`docs/adr/0000-template.md`](./docs/adr/0000-template.md)。
+- ステータス: Accepted / Superseded / Deprecated。
+- ADR は不変。変更する場合は新しい ADR で Supersede する。
+- リンタールールを追加したら対応する ADR を参照すること。
+- harness invariant の追加・緩和も ADR で記録する。
+
+## 品質ゲート（個別コマンド）
+
+タスク完了前に全て Green にする。`make before-commit` がこれらを順に実行する。
 
 ```bash
 nr lint       # biome check
@@ -48,7 +97,7 @@ nr build
 ## Git・CI ルール
 
 - Conventional Commits 形式でコミットする。
-- Issue は `#番号` ではなくフル URL か `Issue 番号` で記述する。
+- Issue は `#番号` ではなくフル URL か `Issue 番号` で記述する（自動クローズ防止）。
 - CI が Green になるまで次に進まない。
 - `gh pr diff` でセルフレビューしてから人間にレビューを依頼する。
 
@@ -66,17 +115,13 @@ nr build
 - 変更済みファイルの一覧。
 - 現在のブランチ名と作業中の Issue 番号。
 - Plan.md の目的とタスク進捗。
-
-## ADR（Architecture Decision Records）
-
-設計判断は `docs/adr/` に ADR として記録する。
-
-- ファイル名: `NNNN-タイトル.md`（例: `0001-biome-を採用.md`）。
-- ステータス: Accepted / Superseded / Deprecated。
-- ADR は不変。変更する場合は新しい ADR で Supersede する。
-- リンタールールを追加したら対応する ADR を参照すること。
+- 未完了のフォローアップタスク（TodoWrite/TaskCreate のうち `[フォローアップ]` 付きのもの）。
 
 ## 禁止事項
 
-- `rm` コマンド使用禁止（ファイル削除はユーザーに依頼する）。
-- モックデータ・スタブ API の使用禁止。
+- `rm` コマンド使用禁止（ファイル削除はユーザーに依頼するか `git rm` を使う）。
+- `npx` 使用禁止（`bunx` または `nlx` を使う。`scripts/architecture-harness.ts` で検出）。
+- モックデータ・スタブ API の使用禁止（`scripts/architecture-harness.ts` で検出）。
+- 設定ファイル（`biome.json` 等）の直接編集禁止（hook で deny される。コードを修正する）。
+- `it.only` / `describe.only` / `xit` / `xdescribe` をコミットに残さない（`scripts/architecture-harness.ts` で検出）。
+- コミット・PR での `#番号` 形式の Issue 引用禁止（自動クローズ防止）。

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,10 @@ architecture_harness:
 	bun scripts/architecture-harness.ts --staged --fail-on=error
 
 .PHONY: before-commit
-before-commit: architecture_harness lint_text lint typecheck test build
+# typecheck / test / build は各 workspace が該当 script を持つ前提に依存するため、本テンプレートの
+# 既定ゲートには含めない。利用プロジェクト側で `before-commit: ... typecheck test build` のように
+# 拡張するか、"no script ならスキップ" 型 runner を用意して取り込むこと。
+before-commit: architecture_harness lint_text lint
 
 .PHONY: dev
 dev:

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,12 @@ format:
 format_check:
 	bun run format:check
 
+.PHONY: architecture_harness
+architecture_harness:
+	bun scripts/architecture-harness.ts --staged --fail-on=error
+
 .PHONY: before-commit
-before-commit: lint_text lint
+before-commit: architecture_harness lint_text lint typecheck test build
 
 .PHONY: dev
 dev:

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,28 @@
+# ADR-NNNN: タイトル
+
+- **Status**: Proposed | Accepted | Superseded by [ADR-XXXX](./XXXX-...md) | Deprecated
+- **Date**: YYYY-MM-DD
+- **Deciders**: 名前 (GitHub handle)
+
+## Context
+
+なぜこの判断が必要なのか。今の状況・制約・課題を 3-5 文で書く。
+過去の試みや、それが失敗した理由があれば添える。
+
+## Decision
+
+何をどうすると決めたか。複数選択肢から 1 つ選んだ理由を含める。
+将来の読者が `git log` や Slack を漁らなくても判断の核が分かるレベルで書く。
+
+## Consequences
+
+- **Good**: この判断で得られるもの
+- **Bad**: この判断で受け入れる痛み
+- **Tradeoff**: 捨てた選択肢と、再検討すべきトリガー
+
+## References
+
+- 関連コード: `path/to/file.ts`
+- 関連 PR / Issue: URL
+- 関連 ADR: [ADR-XXXX](./XXXX-...md)
+- 外部資料: URL

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -1,0 +1,44 @@
+# Architecture Harness
+
+このリポジトリで「セッションが変わっても壊してはいけない原則」を機械可読な ID 付きで固定する正本です。テンプレート利用者は、自分のプロジェクトに合わせて Invariants を追加・調整してください。
+
+## Invariants
+
+- `INVARIANT_NO_NPX`
+  パッケージ実行は `nlx` または `bunx` を使う。`npx` を package.json scripts や CI スクリプト、ドキュメントに残さない。
+- `INVARIANT_NO_MOCK_DATA`
+  `mockData` / `stubApi` / `MOCK_*` などの固定スタブをアプリケーション実装に混ぜない。テストでは Real DB / Real API を使う (`CLAUDE.md` の No Mock 原則と整合)。
+- `INVARIANT_HARNESS_DOC_AUTHORITATIVE`
+  本ファイル (`docs/architecture/harness.md`) と ADR (`docs/adr/`) の内容を仕様の正本とする。コード変更が invariant に違反する場合は、コードを直すのが第一手で、invariant 緩和は ADR で明示的に supersede する。
+- `INVARIANT_PLAN_MD_REQUIRED`
+  機能実装前に `Plan.md` を作成して目的・タスク・検証手順を記録する。実装中の進捗ログと振り返りも `Plan.md` に追記する。
+- `INVARIANT_FOLLOWUP_TRACKED`
+  PR の主目的から外れた発見・改善はその場で実装せず、`/follow-up add` スキルで `.claude/state/follow-ups.jsonl` に記録し、PR 本文の "Known follow-ups" 節 (`/follow-up list-pr-body` で生成) に列挙する。スコープクリープを避け、別 PR で処理する。
+
+## One-Pass Acceptance
+
+- `ONE_PASS_LOCAL`
+  代表的な機能を 1 本、データ層 → API → UI → テストまで一気通貫でローカル動作させる。途中の "見た目だけ動く" や "API は通るけど UI 未実装" は完了扱いにしない。詳細は `Plan.md` の「検証手順」に書く。
+- `ONE_PASS_CI`
+  CI が green になるまで PR は完了扱いにしない。`make before-commit` で通ったものが CI でも通ること。
+
+## Banned Assumptions
+
+- "ローカルで動いた" を完了条件とする運用 (CI green が完了条件)
+- リンター設定ファイルを直接編集して問題を消す運用 (コードを直す)
+- 主目的と無関係な refactor を同 PR に混ぜる運用 (フォローアップに切る)
+- `Plan.md` を作らずに実装を始める運用
+
+## Enforcement
+
+- `bun scripts/architecture-harness.ts --staged --fail-on=error`
+- `make before-commit`
+- `.claude/settings.json` の hooks (rm -rf 等の危険コマンドブロック、リンター設定編集ブロック、PreCompact 状態保存)
+
+## Harness Commands
+
+- 自分の変更だけ厳密チェック: `bun scripts/architecture-harness.ts --staged --fail-on=error`
+- リポジトリ全体スキャン: `bun scripts/architecture-harness.ts`
+- PR 直前の総合ゲート: `make before-commit` (詳細は `CLAUDE.md` の「ゲート」)
+
+Git hook と AI エージェント向けガイド (`CLAUDE.md` / `AGENTS.md`) はこの文書を参照して同じ判定に従います。

--- a/docs/follow-ups.md
+++ b/docs/follow-ups.md
@@ -1,0 +1,18 @@
+# Follow-ups
+
+このファイルは互換性のためのリダイレクトです。フォローアップ管理は **`/follow-up` スキル** に移行しました。
+
+## 使い方
+
+```
+/follow-up                      # 未処理一覧
+/follow-up add <タイトル>       # 追加
+/follow-up resolve <id> <pr-url> # 解消
+/follow-up list-pr-body         # PR 本文用 markdown を生成
+```
+
+詳細: [`.claude/skills/follow-up/SKILL.md`](../.claude/skills/follow-up/SKILL.md)
+
+ストレージ: `.claude/state/follow-ups.jsonl` (gitignore 対象、開発者ごとのローカル状態)
+
+セッション開始時 (SessionStart hook) に未処理件数が Claude に通知される。

--- a/scripts/architecture-harness.ts
+++ b/scripts/architecture-harness.ts
@@ -1,0 +1,338 @@
+#!/usr/bin/env bun
+/**
+ * Architecture Harness — リポジトリ全体の invariant を機械的に検証する。
+ *
+ * 設計:
+ * - 依存ゼロ (Bun ランタイム + 標準モジュールのみ)
+ * - invariant は本ファイル先頭の RULES に並べる。追加は RULES への push のみで完結する
+ * - 実行は `--staged` (git ステージ済の変更だけ) または全件スキャンの 2 モード
+ * - `--fail-on=error|warning` で exit code を制御 (CI / pre-commit hook 用)
+ * - 出力は markdown 1 形式 (TenkaCloud の architecture-harness と互換)
+ *
+ * Invariant の正本は docs/architecture/harness.md。本ファイルはあくまで自動検出器。
+ * docs にあるが script で検出できない invariant は、コードレビューで担保する。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+type Severity = 'error' | 'warning';
+
+interface Finding {
+  rule: string;
+  severity: Severity;
+  file: string;
+  line?: number;
+  message: string;
+}
+
+interface Rule {
+  id: string;
+  description: string;
+  // ファイル単位のチェック (false を返したら skip)
+  scope: (filePath: string) => boolean;
+  check: (file: { path: string; content: string }) => Finding[];
+}
+
+interface RepoCheck {
+  id: string;
+  description: string;
+  check: (root: string) => Promise<Finding[]>;
+}
+
+// --- File-level invariants ---
+
+const RULES: Rule[] = [
+  {
+    id: 'INVARIANT_NO_NPX',
+    description: 'npx ではなく nlx / bunx を使う',
+    scope: (p) =>
+      p.endsWith('package.json') ||
+      p.endsWith('.sh') ||
+      p.endsWith('.yml') ||
+      p.endsWith('.yaml'),
+    check: ({ path: filePath, content }) => {
+      const findings: Finding[] = [];
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // `npx ` (空白付き) を検出。`bunx`/`nlx` は許可。コメントの可能性は許容して error 扱い。
+        if (/(^|\s|"|`|\$\()npx\s/.test(line)) {
+          findings.push({
+            rule: 'INVARIANT_NO_NPX',
+            severity: 'error',
+            file: filePath,
+            line: i + 1,
+            message: 'npx は禁止。nlx または bunx を使う',
+          });
+        }
+      }
+      return findings;
+    },
+  },
+  {
+    id: 'INVARIANT_NO_MOCK_DATA',
+    description: 'アプリケーション実装にスタブ/モックデータを混ぜない',
+    scope: (p) =>
+      (p.startsWith('packages/') || p.startsWith('src/')) &&
+      /\.(ts|tsx|js|jsx)$/.test(p) &&
+      !/\.(test|spec)\.(ts|tsx|js|jsx)$/.test(p) &&
+      !/__mocks__|__fixtures__|test\//.test(p),
+    check: ({ path: filePath, content }) => {
+      const findings: Finding[] = [];
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (/\b(MOCK_[A-Z_]+|mockData|stubApi|fakeUsers)\b/.test(line)) {
+          findings.push({
+            rule: 'INVARIANT_NO_MOCK_DATA',
+            severity: 'error',
+            file: filePath,
+            line: i + 1,
+            message:
+              'アプリ実装に mock/stub/fake データを置かない (テストでは Real DB / Real API を使う)',
+          });
+        }
+      }
+      return findings;
+    },
+  },
+  {
+    id: 'INVARIANT_NO_TEST_FOCUS',
+    description: 'コミット前に .only / .skip / xit / xdescribe を残さない',
+    scope: (p) => /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(p),
+    check: ({ path: filePath, content }) => {
+      const findings: Finding[] = [];
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (
+          /\b(it|test|describe)\.(only|skip)\b/.test(line) ||
+          /\b(xit|xdescribe)\s*\(/.test(line)
+        ) {
+          findings.push({
+            rule: 'INVARIANT_NO_TEST_FOCUS',
+            severity: 'error',
+            file: filePath,
+            line: i + 1,
+            message:
+              'テストの .only / .skip / xit / xdescribe をコミット前に外す',
+          });
+        }
+      }
+      return findings;
+    },
+  },
+];
+
+// --- Repository-level invariants ---
+
+const REPO_CHECKS: RepoCheck[] = [
+  {
+    id: 'INVARIANT_HARNESS_DOC_AUTHORITATIVE',
+    description: 'harness 正本ドキュメントが存在し空でない',
+    check: async (root) => {
+      const harnessPath = path.join(root, 'docs/architecture/harness.md');
+      try {
+        const stats = await stat(harnessPath);
+        if (stats.size < 100) {
+          return [
+            {
+              rule: 'INVARIANT_HARNESS_DOC_AUTHORITATIVE',
+              severity: 'error',
+              file: 'docs/architecture/harness.md',
+              message:
+                'harness.md が空、または極端に短い。invariant を明文化すること',
+            },
+          ];
+        }
+      } catch {
+        return [
+          {
+            rule: 'INVARIANT_HARNESS_DOC_AUTHORITATIVE',
+            severity: 'error',
+            file: 'docs/architecture/harness.md',
+            message: 'docs/architecture/harness.md が存在しない',
+          },
+        ];
+      }
+      return [];
+    },
+  },
+  {
+    id: 'INVARIANT_ADR_TEMPLATE_PRESENT',
+    description: 'ADR テンプレート (docs/adr/0000-template.md) が存在する',
+    check: async (root) => {
+      try {
+        await stat(path.join(root, 'docs/adr/0000-template.md'));
+        return [];
+      } catch {
+        return [
+          {
+            rule: 'INVARIANT_ADR_TEMPLATE_PRESENT',
+            severity: 'warning',
+            file: 'docs/adr/0000-template.md',
+            message:
+              'ADR テンプレートが見つからない。新規 ADR を書く際の正本として用意する',
+          },
+        ];
+      }
+    },
+  },
+  {
+    id: 'INVARIANT_FOLLOWUP_SKILL_PRESENT',
+    description:
+      'フォローアップ管理スキル (.claude/skills/follow-up/SKILL.md) が存在する (scope外発見の受け皿)',
+    check: async (root) => {
+      try {
+        await stat(path.join(root, '.claude/skills/follow-up/SKILL.md'));
+        return [];
+      } catch {
+        return [
+          {
+            rule: 'INVARIANT_FOLLOWUP_SKILL_PRESENT',
+            severity: 'warning',
+            file: '.claude/skills/follow-up/SKILL.md',
+            message:
+              '/follow-up スキルが見つからない。PR の scope 外発見を記録する仕組みを用意する',
+          },
+        ];
+      }
+    },
+  },
+];
+
+// --- File walking ---
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.next',
+  'coverage',
+  'dist',
+  'build',
+  'out',
+  '.turbo',
+  '.cache',
+]);
+
+async function walkRepo(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        await walk(path.join(dir, entry.name));
+        continue;
+      }
+      const rel = path.relative(root, path.join(dir, entry.name));
+      out.push(rel);
+    }
+  }
+  await walk(root);
+  return out;
+}
+
+function listStagedFiles(root: string): string[] {
+  const output = execFileSync(
+    'git',
+    ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
+    { cwd: root, encoding: 'utf8' }
+  );
+  return output
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
+// --- CLI ---
+
+interface CliOptions {
+  root: string;
+  staged: boolean;
+  failOn?: Severity;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { root: process.cwd(), staged: false };
+  for (const arg of argv) {
+    if (arg === '--staged') opts.staged = true;
+    else if (arg.startsWith('--root=')) opts.root = path.resolve(arg.slice(7));
+    else if (arg.startsWith('--fail-on=')) {
+      const v = arg.slice(10);
+      if (v === 'error' || v === 'warning') opts.failOn = v;
+    }
+  }
+  return opts;
+}
+
+function formatReport(findings: Finding[]): string {
+  const errors = findings.filter((f) => f.severity === 'error');
+  const warnings = findings.filter((f) => f.severity === 'warning');
+  const lines: string[] = [
+    '# Architecture Harness Report',
+    '',
+    '## Summary',
+    '',
+    `- Error: ${errors.length}`,
+    `- Warning: ${warnings.length}`,
+    `- Total: ${findings.length}`,
+    '',
+  ];
+  if (findings.length === 0) {
+    lines.push('## Findings', '', '(なし)');
+    return lines.join('\n');
+  }
+  lines.push('## Findings', '');
+  for (const f of findings) {
+    const loc = f.line ? `${f.file}:${f.line}` : f.file;
+    lines.push(`- **[${f.severity.toUpperCase()}] ${f.rule}** — ${loc}`);
+    lines.push(`  ${f.message}`);
+  }
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const findings: Finding[] = [];
+
+  // 1) repository-level checks (常に走らせる)
+  for (const r of REPO_CHECKS) {
+    findings.push(...(await r.check(opts.root)));
+  }
+
+  // 2) file-level checks
+  const candidatePaths = opts.staged
+    ? listStagedFiles(opts.root)
+    : await walkRepo(opts.root);
+
+  for (const rel of candidatePaths) {
+    const applicable = RULES.filter((r) => r.scope(rel));
+    if (applicable.length === 0) continue;
+    let content: string;
+    try {
+      content = await readFile(path.join(opts.root, rel), 'utf8');
+    } catch {
+      continue; // 削除ファイル等
+    }
+    for (const r of applicable) {
+      findings.push(...r.check({ path: rel, content }));
+    }
+  }
+
+  console.log(formatReport(findings));
+
+  if (opts.failOn) {
+    const hit = findings.some((f) =>
+      opts.failOn === 'warning' ? true : f.severity === 'error'
+    );
+    if (hit) process.exitCode = 2;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('[architecture-harness] failed:', err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

TenkaCloud で運用していたハーネス機構をテンプレートに合わせて移植する。最大の目的は **PR スコープクリープを構造的に防ぐ仕組み** を入れること。

### 追加されたもの

- **`docs/architecture/harness.md`** — invariant の正本 (`INVARIANT_NO_NPX` / `NO_MOCK_DATA` / `HARNESS_DOC_AUTHORITATIVE` / `PLAN_MD_REQUIRED` / `FOLLOWUP_TRACKED`) と one-pass 受け入れ条件、banned assumptions
- **`scripts/architecture-harness.ts`** — 依存ゼロ・自己完結の invariant 検出器。`--staged` / `--fail-on=error|warning` 対応。出力は TenkaCloud と同じ markdown 形式
- **`docs/adr/0000-template.md`** — ADR テンプレート (Status / Context / Decision / Consequences / References)
- **`/follow-up` スキル** — scope 外発見を `.claude/state/follow-ups.jsonl` に `add` / `list` / `resolve` / `list-pr-body` するサブコマンド設計
- **`/architecture-harness` スキル** — 検証実行と `why <RULE_ID>` で invariant の意図を harness.md から引く
- **SessionStart hook** (`.claude/scripts/follow-up-reminder.sh`) — 未処理フォローアップ件数を Claude に systemMessage 通知
- **Stop hook** (`.claude/scripts/stop-gate-reminder.sh`) — TS 変更があればゲート (architecture-harness → make before-commit → /review /security-review /simplify) とフォローアップ運用を再リマインド
- **CLAUDE.md / AGENTS.md** — ゲート順序、作業順序 (docs → refactor → feature)、フォローアップ運用を明文化
- **Makefile** — `architecture_harness` target 追加、`before-commit` に統合
- **.gitignore** — `.claude/state/*.jsonl` を開発者ローカル状態として除外

### 設計判断

- フォローアップは docs ベースではなく **スキル + JSONL 状態ファイル** にした (PR ごとに docs を編集するとコンフリクトが多発するため)
- ハーネス検出器は `packages/shared` 等への依存を切り、Bun + 標準モジュールのみで動く 1 ファイル実装にした (テンプレートのコピー価値を保つため)
- hook はスキル本体を直接呼ばず systemMessage で suggest する形にした (Claude が文脈を読んでスキル起動を判断)

## Test plan

- [x] \`bun scripts/architecture-harness.ts\` で 0 errors / 0 warnings
- [x] \`bun scripts/architecture-harness.ts --staged --fail-on=error\` で 0 件
- [x] \`make architecture_harness\` が同じ結果を出す
- [x] \`bash .claude/scripts/follow-up-reminder.sh\` を空状態 / 2 件未処理 / 1 件未処理で smoke test → 期待通り JSON 出力
- [x] \`bash .claude/scripts/stop-gate-reminder.sh\` を TS 変更なし / あり で smoke test
- [x] \`make lint_text lint\` 通過
- [x] \`.claude/settings.json\` schema validation 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Architecture invariant checking system validates code against defined harness rules on pre-commit
  * Follow-up tracking system enables persistent recording and management of out-of-scope discoveries
  * Enhanced pre-commit quality gates with TypeScript change detection and session reminders

* **Documentation**
  * Added Architecture Decision Record (ADR) template for documenting architectural decisions
  * Comprehensive architecture harness documentation defining repository invariants and enforcement
  * Agent procedures and quality gate guidelines documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->