### PR TITLE
[codex] 公開品質ガードと blindspot-pass を追加

### DIFF
--- a/.claude/skills/blindspot-pass/SKILL.md
+++ b/.claude/skills/blindspot-pass/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: blindspot-pass
+description: Issue、ADR、設計メモ、実装計画、PR diff、指定 path に対し、書かれていない前提、producer / consumer の未接続、実運用だけで露出する failure path をコードと設定の証拠付きで探索する review-only スキル。実装前、設計レビュー、PR 前に未知や blocker を確認するときに使う。
+argument-hint: "<Issue|ADR|design-note|PR|path>"
+allowed-tools: Read, Grep, Glob, Bash(git diff:*), Bash(gh issue view:*), Bash(gh pr view:*), Bash(gh pr diff:*)
+---
+
+# Blindspot pass
+
+対象を変更せず、計画を無効化しうる未知を調査して報告する。
+コード修正、PR 作成、Issue 起票、設定変更は行わない。
+通常レビュー、セキュリティレビュー、テストの代わりに使わない。
+
+## 入力を解決する
+
+1. 引数が Issue / PR の URL または番号なら `gh` で本文、コメント、diff を読む。
+2. ADR / 設計メモ / path なら `Read`、`Glob`、`Grep` で対象と参照先を読む。
+3. 引数がない場合は、現在の diff と関連する設計文書を対象にする。
+4. 対象の主張、変更する経路、依存する producer / consumer、データ境界を列挙する。
+
+対象を特定できない場合は、推測で補わず必要な入力を一つだけ確認する。
+
+## 調査する
+
+次の 10 観点を省略しない。該当しない場合も、該当しない根拠を持つ。
+
+1. producer / consumer の未接続
+2. API / CLI / Worker / Lambda / workflow など経路ごとの差分
+3. identity / tenant / account / role / audience の生成、伝搬、検証
+4. DB / projection / cache / queue 間の data seam
+5. create / deploy / destroy / retry / rollback / sweeper の lifecycle 一貫性
+6. 4xx / 5xx / timeout / partial failure / default 値の fail-open
+7. secret / signing / cross-account / 最小権限
+8. tags / audit / metrics / alert / cost backstop / 手動復旧
+9. ADR / OpenAPI / schema / IaC / workflow / docs / tests の spec drift
+10. unit test は Green だが実経路を通らない test illusion
+
+対象から実行経路を両方向にたどる。入口から consumer まで進み、永続化・非同期処理・
+外部依存から入口へ戻って caller と cleanup を確認する。名前が似ているだけで接続済みと
+判断せず、import、binding、route、event source、workflow step、権限、設定値を確認する。
+
+## 証拠を扱う
+
+- 確認済みの事実には `path:line`、symbol、または再現可能な read-only command を付ける。
+- 検索結果がゼロであることを根拠にする場合は、検索語と探索した path を示す。
+- 直接証拠がない内容を finding と断定しない。「未検証のまま残る事項」に仮説として置く。
+- severity は発生可能性ではなく、成立した場合の影響と出荷判断への影響で決める。
+- blocker は、計画の前提を無効化する、データや権限境界を壊す、回復不能にする、
+  または実経路の検証を欠く場合に `yes` とする。
+- 是正方向は最小の設計方向までに留め、実装手順やコード変更へ踏み込まない。
+
+## 出力する
+
+```md
+# Blindspot pass: <対象>
+
+## 結論
+- 進めてよい / 条件付きで進めてよい / blocker を先に解くべき
+- 最重要の未知: <1行>
+
+## 発見
+### [Critical|High|Medium|Low] <タイトル>
+- 何が起きるか:
+- 証拠: `path:line` / symbol / command
+- なぜ見落としやすいか:
+- 影響範囲:
+- 最小の是正方向:
+- blocker 判定: yes / no
+
+## 未検証のまま残る事項
+
+## 次のアクション
+```
+
+発見がない場合も「発見なし」とし、確認した経路と未検証事項を省略しない。
+事実と仮説を同じ箇条書きへ混ぜない。
+
+小さい実行例は [references/example.md](./references/example.md) を参照する。

--- a/.claude/skills/blindspot-pass/references/example.md
+++ b/.claude/skills/blindspot-pass/references/example.md
@@ -1,0 +1,41 @@
+# Blindspot pass 実行例
+
+## Fixture
+
+対象設計 `docs/design/jobs.md`:
+
+```text
+API が Job を DB に作成して queue へ publish する。
+Worker が queue を consume して Job を完了にする。
+Job 削除時は DB row を削除する。
+```
+
+対象実装:
+
+```text
+src/api/jobs.ts       createJob と deleteJob
+src/queue/publish.ts  publishJob
+src/worker/run.ts     processJob
+deploy/api.yml        API と queue binding
+deploy/worker.yml     Worker。queue event source の記載なし
+```
+
+## Invocation
+
+```text
+/blindspot-pass docs/design/jobs.md
+```
+
+## Expected evidence and classification
+
+- `deploy/worker.yml` に queue event source がなく、Worker consumer が起動しないことは、
+  path と設定 symbol を示せるため High finding にする。
+- `deleteJob` が DB row だけを削除し、queue 内の未処理 message を失効させる経路がないことは、
+  API symbol と検索結果を根拠に lifecycle finding にする。
+- retry 時に外部副作用が重複するかは、外部 API 実装が fixture にないため断定しない。
+  「未検証のまま残る事項」に仮説として置く。
+
+## Expected conclusion
+
+consumer の未接続が主経路を無効化するため「blocker を先に解くべき」と判定する。
+スキルは設定やコードを修正せず、接続と lifecycle の最小是正方向だけを報告する。

--- a/.claude/skills/init-project/SKILL.md
+++ b/.claude/skills/init-project/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: init-project
 description: プロジェクトを Bun + Hono（バックエンド）+ Vite + React（フロントエンド）+ Biome でスキャフォールドする初期化スキル。テンプレートを clone した直後の初回セットアップ時に、ユーザーが明示的に実行する。
+allowed-tools: Read, Write, AskUserQuestion, Bash(bun install --ignore-scripts:*), Bash(nr:*)
 disable-model-invocation: true
 ---
 
@@ -44,6 +45,7 @@ disable-model-invocation: true
 
 1. バックエンドのみ、フロントエンドのみ、フルスタックのどれか。
 2. プロジェクト固有の追加依存（例: Prisma, Drizzle, Zod など）があるか。
+3. フロントエンドを作る場合、公開 URL、サービス名、description、OGP 画像の絶対 URL。
 
 ---
 
@@ -246,7 +248,14 @@ export default defineConfig({
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>App</title>
+    <meta name="description" content="<DESCRIPTION>" />
+    <link rel="canonical" href="<PUBLIC_URL>" />
+    <meta property="og:title" content="<SERVICE_NAME>" />
+    <meta property="og:description" content="<DESCRIPTION>" />
+    <meta property="og:url" content="<PUBLIC_URL>" />
+    <meta property="og:image" content="<OG_IMAGE_URL>" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <title><SERVICE_NAME></title>
   </head>
   <body>
     <div id="root"></div>
@@ -254,6 +263,9 @@ export default defineConfig({
   </body>
 </html>
 ```
+
+`<PUBLIC_URL>`、`<SERVICE_NAME>`、`<DESCRIPTION>`、`<OG_IMAGE_URL>` は
+手順 1 で確認した実値に置換する。プレースホルダーのままファイルを作成しない。
 
 ### packages/frontend/src/main.tsx
 
@@ -279,10 +291,10 @@ createRoot(root).render(
 
 ## 手順 5: 依存をインストールする
 
-ルートで `bun install` を実行するだけで全ワークスペースの依存が一括インストールされる。
+ルートで lifecycle script を無効にして依存をインストールする。
 
 ```bash
-bun install
+bun install --ignore-scripts
 ```
 
 ## 手順 6: 動作確認する
@@ -292,6 +304,7 @@ nr test           # 全ワークスペースのユニットテストが通るこ
 nr typecheck      # 型エラーがないこと
 nr test:e2e       # フロントエンドの E2E テストが通ること（packages/frontend）
 nr test:api       # バックエンドの API テストが通ること（packages/backend、hurl が必要）
+nr check:pre-release # 公開品質 invariant が通ること
 ```
 
 ## 手順 7: ユーザーに完了報告する

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -126,7 +126,22 @@ AI に丸投げで生成したテストは、実行パスを本当にカバー�
 - [ ] _検証コマンド / 観察 signal_
 - [ ] _tear-down で元に戻せるか (dev 環境)_
 
-## 既知の未完了 (scope 外)
+## 公開品質チェック
+
+変更種別に応じて
+[`docs/checklists/pre-release.md`](../docs/checklists/pre-release.md) から詳細を確認する。
+
+- [ ] UI 変更: accessibility / responsive / loading / error / empty state を確認した
+- [ ] 公開ページ変更: SEO / OGP / canonical / noindex を確認した
+- [ ] API 変更: server-side validation / authorization / error response を確認した
+- [ ] Auth 変更: token storage / Cookie attributes / enumeration risk を確認した
+- [ ] Infra 変更: cache / security headers / logs / alarms / rollback を確認した
+- [ ] `bun run check:pre-release` が完了した
+- [ ] 該当なしの場合、理由を下に記載した
+
+該当なしの理由:
+
+## Known follow-ups
 
 <!-- この PR で解決しない既知問題。scope から除外した理由、後続 issue / PR 案を明示 -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ permissions:
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -50,6 +51,7 @@ jobs:
           CI: "true"
         run: make install_ci
 
-      - name: lint typecheck test build
+      - name: Run quality gates
         run: |
+          bun scripts/architecture-harness.ts --fail-on=error
           make before-commit

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,15 @@ architecture_harness:
 harness_test:
 	bun test scripts/
 
+.PHONY: pre_release_check
+pre_release_check:
+	bun run check:pre-release
+
 .PHONY: before-commit
 # typecheck / test / build は各 workspace が該当 script を持つ前提に依存するため、本テンプレートの
 # 既定ゲートには含めない。利用プロジェクト側で `before-commit: ... typecheck test build` のように
 # 拡張するか、"no script ならスキップ" 型 runner を用意して取り込むこと。
-before-commit: architecture_harness harness_test lint_text lint
+before-commit: architecture_harness harness_test pre_release_check lint_text lint
 
 .PHONY: dev
 dev:

--- a/Plan.md
+++ b/Plan.md
@@ -1,5 +1,65 @@
 # Plan.md
 
+### 公開品質ガードと blindspot pass - 2026-07-04
+
+#### 目的
+
+Issue 112 と Issue 120 を実装し、テンプレートから生成したプロジェクトに
+公開前チェック、機械検査、PR / CI 導線、未知を証拠付きで探索する
+review-only スキルを標準搭載する。
+
+#### 制約
+
+- 作業順序は docs 更新、harness の責務整理、テスト、機能実装とする。
+- 新 invariant は `docs/architecture/harness.md` と ADR-0006 を正本にする。
+- 自動検出が不確実な項目は error にせず、人間向けチェックリストに残す。
+- 既存の未コミット `package.json` 変更を保持する。
+- `.claude/` を変更するため、通常ゲートに加えて skill-audit を通す。
+
+#### タスク
+
+1. 設計、ADR、harness 正本を先に更新する。
+2. architecture harness に `pre-release` ルールグループを追加する。
+3. 公開品質ルールをテスト先行で追加する。
+4. チェックリスト、PR テンプレート、CI、README、package script を接続する。
+5. `blindspot-pass` スキル、fixture、実行例、skills index を追加する。
+6. architecture harness、before-commit、skill-audit、review、
+   security-review、simplify の各ゲートを通す。
+
+#### 検証手順
+
+- `bun test scripts/`
+- `bun run check:pre-release`
+- `bun scripts/architecture-harness.ts --fail-on=warning`
+- `make before-commit`
+- `.claude/skills/skill-audit/SKILL.md` の Quick Workflow
+
+#### 進捗ログ
+
+- 2026-07-04: 設計と ADR-0006 を先に追加し、専用スキャナではなく既存 harness の
+  rule group として公開品質検査を統合した。
+- 2026-07-04: 7 invariant、`--pre-release`、複数行 JSX / 動的属性、
+  ローカル worktree 除外をテスト先行で実装した。68 tests が Green。
+- 2026-07-04: 5 チェックリスト、PR テンプレート、GitHub Actions、
+  init-project、README、package command を接続した。
+- 2026-07-04: review-only の `blindspot-pass` と fixture / 実行例を追加した。
+  skill-audit の機械検査と目視レビューは指摘なし。
+- 2026-07-04: 全 harness、公開品質検査、変更対象の Biome / textlint、
+  `git diff --check` は Green。開始時から存在した未コミットの
+  `package.json` 変更が textlint を過去の immutable ADR まで拡張し、
+  既存文書 60 件で `make before-commit` を停止させるため、このユーザー変更は
+  上書きせず判断待ちとした。
+- 2026-07-04: workspace は未生成のため、ルートの typecheck / test / build は
+  `No packages matched the filter` となる。harness の 68 tests は個別に完了した。
+
+#### 振り返り
+
+- 高シグナルな構文検査と、人間が実行経路や運用環境を判断するチェックを分離した。
+- 通常 harness と公開前専用 command が同じ rule 実装を使うため、判定差分を作らない。
+- 動的 `rel` の安全性は断定せず warning とし、fail-open を避けた。
+
+---
+
 ### 品質ファースト化（MVP・三流コードの再発防止） - 2026-06-13
 
 #### 目的

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ make format         # biome format
 make typecheck      # tsc --noEmit（全ワークスペース）
 make test           # bun test（全ワークスペース）
 make harness_test   # architecture-harness の検出ロジックをテスト
+nr check:pre-release # 公開品質 invariant を全件スキャン
 make build          # ビルド（全ワークスペース）
-make before-commit  # コミット前チェック（harness + harness_test + lint_text + lint）
+make before-commit  # コミット前チェック（harness + test + 公開品質 + lint）
 ```
 
 ## スキル
@@ -51,6 +52,7 @@ make before-commit  # コミット前チェック（harness + harness_test + lin
 | `/architecture-harness` | invariant の機械検証。`why <RULE_ID>` で意図を表示 |
 | `/skill-audit` | スキル・フック・設定の監査。サードパーティスキルの導入前検査 |
 | `/follow-up` | scope 外の発見をフォローアップとして記録・解消管理 |
+| `/blindspot-pass` | 設計・Issue・PR・実装経路の未知を証拠付きで探索する review-only 検査 |
 | `/frontend-design` | 高品質なフロントエンド実装 |
 
 ## ディレクトリ構成
@@ -91,6 +93,19 @@ make before-commit  # コミット前チェック（harness + harness_test + lin
 - `INVARIANT_SKILL_NO_EXFIL_EXEC` — リモート取得のシェルパイプ実行・base64 デコード実行の検出。
 
 サードパーティスキルの導入前検査と目視レビューのチェックリストは `/skill-audit` スキルに集約している。設計判断は [ADR-0002](./docs/adr/0002-skill-audit-invariants.md) を参照。
+
+## 公開前レビュー
+
+公開前の人間向け確認事項は
+[公開前チェックリスト](./docs/checklists/pre-release.md) を入口に、
+セキュリティ、アクセシビリティ、SEO / OGP、運用へ分割している。
+`nr check:pre-release` は、認証情報のブラウザ保存、危険な HTML 出力、
+安全でない外部リンク、画像の代替テキスト不足、公開 metadata の不足、
+本番ページの `noindex` を検出する。PR テンプレートと GitHub Actions から同じゲートを実行する。
+
+機械検査できない認可、cache、復旧、監視はチェックリストとレビューで確認する。
+設計判断と自動化の境界は
+[ADR-0006](./docs/adr/0006-pre-release-quality-guardrails.md) を参照。
 
 ## 開発ガイドライン
 

--- a/docs/adr/0006-pre-release-quality-guardrails.md
+++ b/docs/adr/0006-pre-release-quality-guardrails.md
@@ -1,0 +1,47 @@
+# ADR-0006: 公開品質ガードを architecture harness に統合する
+
+- Status: Accepted
+- Date: 2026-07-04
+
+## Context
+
+公開前に必要なセキュリティ、アクセシビリティ、SEO、パフォーマンス、運用の確認は、
+プロジェクトごとの手作業では漏れる。一方、すべてを静的検査しようとすると、
+認可や復旧可能性のような意味判断で誤検知が増える。
+
+本リポジトリには既に、ファイル探索、finding 形式、除外規則、CI 接続を持つ
+architecture harness がある。公開品質専用スキャナを別に実装すると、
+同じリポジトリに 2 つの判定経路が生まれる。
+
+## Decision
+
+公開品質の高シグナルな静的規則を architecture harness の `pre-release`
+ルールグループとして追加する。通常 harness は従来どおり全規則を実行し、
+`--pre-release` はこのグループだけを実行する。
+
+認証情報のブラウザ保存、危険な HTML 出力、安全でない外部リンク、
+画像の代替テキスト不足、公開 HTML のメタデータ不足、本番向けページの
+`noindex` を error とする。icon-only button の accessible name 不足は、
+静的に確定できない場合があるため warning とする。
+
+認可、ユーザー別キャッシュ、メール到達性、バックアップ復旧、監視など、
+実装の意味や運用環境が必要な判断は `docs/checklists/` とレビューで担保する。
+console のデバッグ出力は既存の Biome `noConsole` に委譲する。
+
+## Consequences
+
+- 通常ゲートと `check:pre-release` が同じ検出ロジックを使う。
+- 新しい公開品質 invariant は文章正本、実装、テストを同時に更新する必要がある。
+- 人間向けチェックリストと機械検査の責務境界が明示される。
+- 意味解析が必要な項目は自動合格にならず、PR テンプレートで確認理由を残す。
+
+## Alternatives
+
+- 独立した `pre-release-check.ts`: 探索・出力・除外規則が重複するため不採用。
+- チェックリストのみ: 決定論的に検出できる重大事故を止められないため不採用。
+
+## References
+
+- [設計](../design/2026-07-04-open-issues-112-120.md)
+- [Harness invariants](../architecture/harness.md)
+- https://github.com/susumutomita/typescript-template/issues/112

--- a/docs/architecture/harness.md
+++ b/docs/architecture/harness.md
@@ -38,6 +38,27 @@
   `packages/` / `src/` / `scripts/` のアプリ・ツール実装に、手抜き・未完成の客観的シグナルを残さない (error)。対象はコメント内の作業中マーカー (TODO / FIXME / HACK / XXX、大小無視) と `not implemented` / `unimplemented` 系の throw。やり残しは `/follow-up` に切るか、その場で完了させる。役割分担: 空 catch は Biome の `noEmptyBlockStatements`、`any` は `noExplicitAny` が AST で拾う (linter で取れるものは linter に任せ、harness は linter に対応ルールが無いものだけを見る)。MVP を完了条件にしない原則 ([quality-bar.md](./quality-bar.md)) の機械的な裏打ち。
 - `INVARIANT_NO_TYPE_ESCAPE_HATCH`
   `packages/` / `src/` / `scripts/` の TypeScript に、Biome が拾わない型エスケープを残さない (error)。対象は `as unknown as` の二段キャストと `@ts-nocheck` / `@ts-expect-error`。型を回避せず、外部入力は境界で検証して内部では検証済みの型だけを扱う。`any` / `as any` は Biome `noExplicitAny`、`@ts-ignore` は Biome `noTsIgnore` が担当する。
+- `INVARIANT_NO_CLIENT_AUTH_STORAGE`
+  `packages/` / `src/` のブラウザ実装で、token / auth / session / credential を示すキーや値を `localStorage` / `sessionStorage` に保存しない (error)。認証情報は JavaScript から読めない HttpOnly Cookie など、脅威モデルに合うサーバー管理方式を使う。
+- `INVARIANT_NO_DANGEROUS_HTML`
+  `packages/` / `src/` の実装で `dangerouslySetInnerHTML` や DOM `innerHTML` 代入を使わない (error)。ユーザー入力を HTML として直接解釈せず、例外が必要なら sanitizer と threat model を ADR で設計して invariant を supersede する。
+- `INVARIANT_EXTERNAL_LINK_SAFE`
+  JSX / HTML の `target="_blank"` には `rel="noopener noreferrer"` を両方指定する (error)。複数行タグと動的な属性値も属性の存在を検査する。
+- `INVARIANT_IMAGE_ALT_REQUIRED`
+  JSX / HTML のネイティブ `img` には `alt` 属性を必須とする (error)。装飾画像は空 `alt`、意味のある画像は内容を表す代替テキストを指定する。
+- `INVARIANT_ICON_BUTTON_ACCESSIBLE_NAME`
+  JSX / HTML でアイコン要素だけを持つ `button` は `aria-label` / `aria-labelledby` / `title` のいずれかを持つことを確認する。子コンポーネントが表示文字列を生成する可能性を静的に確定できないため warning とし、アクセシビリティレビューで最終確認する。
+- `INVARIANT_PUBLIC_METADATA_PRESENT`
+  公開ページの入口となる `index.html` は `html lang`、meta description、canonical URL、Open Graph (`og:title` / `og:description` / `og:url` / `og:image`)、Twitter Card を持つ (error)。
+- `INVARIANT_NO_PRODUCTION_NOINDEX`
+  `packages/` / `src/` の本番向け HTML / JSX / TSX に `noindex` を残さない (error)。検索非公開が製品要件の場合は対象 path を分離し、設計判断を ADR に残す。
+
+上記 7 件は `pre-release` ルールグループに属する。通常 harness では他の invariant と
+一緒に実行し、`bun scripts/architecture-harness.ts --pre-release` では公開品質規則だけを
+全件実行する。console のデバッグ出力は Biome `noConsole`、認可・キャッシュ・復旧・
+監視など意味解析が必要な項目は [公開前チェックリスト](../checklists/pre-release.md) と
+コードレビューが担当する。設計判断は
+[ADR-0006](../adr/0006-pre-release-quality-guardrails.md) を参照。
 
 ## Definition of Done
 
@@ -70,6 +91,11 @@
 
 - 自分の変更だけ厳密チェック: `bun scripts/architecture-harness.ts --staged --fail-on=error`
 - リポジトリ全体スキャン: `bun scripts/architecture-harness.ts`
+- 公開品質ルールだけを全件スキャン: `bun scripts/architecture-harness.ts --pre-release --fail-on=error`
 - PR 直前の総合ゲート: `make before-commit` (詳細は `CLAUDE.md` の「ゲート」)
+
+全件スキャンは Claude Code が作るローカル専用の `.claude/worktrees/` を除外する。
+各 worktree は別の Git checkout としてそれぞれ検査し、親 checkout から複製内容を
+重複検査しない。
 
 Git hook と AI エージェント向けガイド (`CLAUDE.md` / `AGENTS.md`) はこの文書を参照して同じ判定に従います。

--- a/docs/checklists/accessibility.md
+++ b/docs/checklists/accessibility.md
@@ -1,0 +1,16 @@
+# アクセシビリティチェックリスト
+
+WCAG 2.1 AA を基準に、キーボードと支援技術で主要操作を完了できることを確認する。
+
+- [ ] 意味のある画像に内容を表す `alt`、装飾画像に空 `alt` を指定する
+- [ ] icon-only button / link に `aria-label` などの accessible name がある
+- [ ] 見出し階層、landmark、label と入力欄の対応が意味構造どおりである
+- [ ] Tab / Shift+Tab / Enter / Space / Escape で主要操作を完了できる
+- [ ] focus indicator が見え、DOM 順と視覚順が一致する
+- [ ] modal / dialog の初期 focus、focus trap、閉じた後の focus 復帰を確認する
+- [ ] toast / 非同期更新は `role="status"`、即時対応が必要な error は `role="alert"` で通知する
+- [ ] error を色だけで示さず、テキストまたはアイコンと accessible name を併用する
+- [ ] 通常文字、large text、UI 部品のコントラストが AA を満たす
+- [ ] 200％ zoom と狭い viewport で情報や操作が失われない
+- [ ] motion を減らす設定を尊重し、点滅や自動再生を制御できる
+- [ ] loading / error / empty / success の各状態をスクリーンリーダーでも識別できる

--- a/docs/checklists/operations.md
+++ b/docs/checklists/operations.md
@@ -1,0 +1,32 @@
+# 運用チェックリスト
+
+## ログ、メトリクス、アラーム
+
+- [ ] frontend error、5xx、auth error、timeout、queue failure を検知できる
+- [ ] request / trace ID で入口から依存先まで追跡できる
+- [ ] logs / metrics / alarms の owner、通知先、閾値、抑制条件を確認する
+- [ ] 404 / 50x ページに安全な戻り導線と問い合わせ情報がある
+- [ ] audit log に actor、target、action、result、時刻が残る
+- [ ] 利用量、queue depth、storage、外部 API 課金に cost backstop がある
+
+## 復旧と lifecycle
+
+- [ ] DB / object storage / 設定データの backup 頻度、保持期間、暗号化を確認する
+- [ ] restore を実際に試し、RPO / RTO と手順を記録する
+- [ ] create / deploy / retry / rollback / destroy / sweeper の対象が一致する
+- [ ] partial failure と再実行で二重作成、重複課金、孤児リソースが発生しない
+- [ ] 手動復旧の判断条件、権限、コマンド、検証 signal を runbook に残す
+
+## メールと通知
+
+- [ ] SPF / DKIM / DMARC の設定と alignment を確認する
+- [ ] at-least-once 実行でも idempotency key で重複通知を抑止する
+- [ ] 大量通知の rate limit、backoff、dead letter、再送上限を確認する
+- [ ] unsubscribe、bounce、complaint、suppression の処理を確認する
+- [ ] template 変数の欠落や個人情報の誤送信を防ぐ境界検証がある
+
+## リリース
+
+- [ ] migration の forward / rollback、互換期間、長時間 lock を確認する
+- [ ] feature flag の default、段階展開、緊急停止、削除期限を確認する
+- [ ] deploy 後の正常 signal と異常時の rollback 条件を明記する

--- a/docs/checklists/pre-release.md
+++ b/docs/checklists/pre-release.md
@@ -1,0 +1,38 @@
+# 公開前チェックリスト
+
+公開または本番反映の前に、変更種別に応じた詳細チェックリストを確認する。
+機械検査は `bun run check:pre-release`、意味判断は本チェックリストとレビューが正本になる。
+
+## 変更種別
+
+- UI: [アクセシビリティ](./accessibility.md) と下記パフォーマンス
+- 公開ページ: [SEO / OGP](./seo-ogp.md) と [アクセシビリティ](./accessibility.md)
+- API / Auth: [セキュリティ](./security.md)
+- Infra / メール / データ: [運用](./operations.md) と [セキュリティ](./security.md)
+- 複数にまたがる変更: 該当するチェックリストをすべて確認する
+
+該当しないチェックは、PR の「公開品質チェック」に理由を書く。
+
+## 機械検査
+
+- [ ] `bun run check:pre-release` が error なしで完了する
+- [ ] `make before-commit` が完了する
+- [ ] warning を確認し、許容する場合は根拠を PR に書く
+- [ ] 検出器を回避する変更ではなく、実装を是正している
+
+## パフォーマンス
+
+- [ ] 主要ページの bundle size と遅延読み込み境界を確認した
+- [ ] 追加した依存が既存 API や Web Platform で代替できないことを確認した
+- [ ] 静的ファイルに content hash と長期 CDN cache を設定した
+- [ ] HTML とユーザー別 API レスポンスを同じ cache policy にしていない
+- [ ] 画像の実寸、圧縮、遅延読み込み、幅と高さを確認し、layout shift を抑えた
+- [ ] API / DB の主要アクセスパターン、件数上限、N+1、timeout を確認した
+- [ ] 低速回線、低速端末、空 cache でも主要操作を完了できる
+
+## リリース判定
+
+- [ ] loading / error / empty / success の全状態を確認した
+- [ ] 4xx / 5xx / timeout / partial failure の利用者向け挙動を確認した
+- [ ] rollback と、既に発生したデータや副作用の扱いを確認した
+- [ ] 未確認事項がない。残る場合は DRAFT のままにし、owner と確認期限を書く

--- a/docs/checklists/security.md
+++ b/docs/checklists/security.md
@@ -1,0 +1,41 @@
+# セキュリティチェックリスト
+
+## セッションと Cookie
+
+- [ ] 認証 token を `localStorage` / `sessionStorage` に保存していない
+- [ ] セッション Cookie の `HttpOnly` / `Secure` / `SameSite` / `Domain` / expiry を確認した
+- [ ] CSRF、セッション rotation、logout 後の失効方針を確認した
+- [ ] 秘匿値、token、Cookie、個人情報をログとエラー応答に含めていない
+
+## 入力と出力
+
+- [ ] 外部入力をサーバー境界で型・長さ・形式・許可値まで検証する
+- [ ] クライアント側検証だけに依存していない
+- [ ] URL は許可する protocol を列挙し、危険な protocol を拒否する
+- [ ] ユーザー入力を HTML として直接出力していない
+- [ ] `dangerouslySetInnerHTML`、DOM HTML 代入、template injection の経路がない
+- [ ] エラー応答に stack trace、SQL、内部 path、依存バージョンを出していない
+
+## 認証と認可
+
+- [ ] tenant / organization / project / user の境界を API 側で検証する
+- [ ] read / create / update / delete の全操作で object-level authorization を確認する
+- [ ] role / audience / issuer / expiry を信頼境界ごとに検証する
+- [ ] メール確認前に許可する操作を明記する
+- [ ] login / invite / password reset の応答や時間差でアカウントを列挙できない
+- [ ] 招待・再設定リンクの有効期限、単回利用、再発行時の失効を確認する
+
+## ヘッダとキャッシュ
+
+- [ ] HSTS を HTTPS の全本番ホストに設定する
+- [ ] CSP を設定し、少なくとも `frame-ancestors` で埋め込み元を制限する
+- [ ] `X-Content-Type-Options: nosniff` と `Referrer-Policy: strict-origin-when-cross-origin` 以上に制限的な方針を設定する
+- [ ] ユーザー別応答を共有 CDN / ブラウザ cache に保存しない
+- [ ] CORS は必要な origin、method、header、credential だけを許可する
+
+## 秘匿値と権限
+
+- [ ] secret をソース、画像、bundle、ログ、CI artifact に含めていない
+- [ ] signing key の保管、rotation、失効、複数鍵移行を確認する
+- [ ] cross-account / cross-tenant の trust policy と最小権限を確認する
+- [ ] dependency と action の追加を supply-chain 規則に沿って確認する

--- a/docs/checklists/seo-ogp.md
+++ b/docs/checklists/seo-ogp.md
@@ -1,0 +1,14 @@
+# SEO / OGP チェックリスト
+
+- [ ] ページ固有の title と meta description を設定する
+- [ ] 正規 URL を canonical に設定し、query / trailing slash 方針と一致させる
+- [ ] 本番公開対象に `noindex` / `nofollow` が残っていない
+- [ ] `og:title` / `og:description` / `og:url` / `og:image` を設定する
+- [ ] `twitter:card` と必要な Twitter metadata を設定する
+- [ ] OGP 画像が絶対 URL で取得でき、共有先の推奨寸法と容量を満たす
+- [ ] favicon と apple-touch-icon を設定する
+- [ ] `html lang` がページ言語と一致する
+- [ ] robots.txt と sitemap の対象範囲が公開方針と一致する
+- [ ] redirect、404、削除済み URL の canonical と status code が正しい
+- [ ] staging / preview host を検索対象から除外し、本番設定と混同していない
+- [ ] structured data を使う場合、画面表示と内容が一致し validator を通る

--- a/docs/design/2026-07-04-open-issues-112-120.md
+++ b/docs/design/2026-07-04-open-issues-112-120.md
@@ -1,0 +1,86 @@
+# 公開品質ガードと blindspot pass の設計
+
+対象は次の Issue です。
+
+- Issue 112: https://github.com/susumutomita/typescript-template/issues/112
+- Issue 120: https://github.com/susumutomita/typescript-template/issues/120
+
+## 目的
+
+テンプレートから作るプロジェクトに、公開前の人間向け確認事項と高シグナルな
+機械検査を最初から含める。また、設計・Issue・PR・実装経路に書かれていない前提を、
+コードと設定の証拠にもとづいて報告する review-only スキルを追加する。
+
+## 選択肢
+
+### A. 公開品質専用スキャナを新設する
+
+`scripts/pre-release-check.ts` に独立した探索・出力・CLI を実装する。
+
+- 利点: 公開品質だけを独立して変更できる。
+- 欠点: ファイル探索、finding、CLI、出力、除外規則が
+  `architecture-harness.ts` と重複し、通常ゲートと専用コマンドの判定がずれる。
+
+### B. architecture harness にルールグループを追加する
+
+既存 `Rule` にグループを付け、通常実行では全ルール、
+`--pre-release` では公開品質ルールだけを実行する。
+
+- 利点: 通常ゲート、CI、専用コマンドが同じ検出ロジックを使う。
+- 利点: finding 形式、除外規則、テスト方法を再利用できる。
+- 欠点: harness の責務が増えるため、ルールの単一責務とテスト分離が必要になる。
+
+### C. チェックリストだけを追加する
+
+- 利点: 誤検知がなく、短期間で導入できる。
+- 欠点: 認証情報のブラウザ保存や危険な HTML 出力など、
+  決定論的に止められる事故もレビュー依存になる。
+
+## 決定
+
+B を採用する。公開品質ルールには `pre-release` グループを付け、通常の
+architecture harness と `bun run check:pre-release` の両方から実行する。
+
+次の高シグナルな規則を error として機械検査する。
+
+- 認証情報らしい値の `localStorage` / `sessionStorage` 保存
+- `dangerouslySetInnerHTML` と DOM `innerHTML` 代入
+- `target="_blank"` で `noopener noreferrer` が不足するリンク
+- `alt` のないネイティブ `img`
+- 公開 HTML の description / canonical / OGP / Twitter Card / `lang` 不足
+- アプリ実装に残る `noindex`
+
+icon-only button の accessible name 不足は、静的解析で子コンポーネントの表示文字列を
+確定できないため warning とする。console のデバッグ出力は Biome、認可・キャッシュ・
+復旧・監視など意味解析が必要な項目はチェックリストとレビューが正本になる。
+
+`blindspot-pass` は入力を変更しない。Issue、ADR、設計メモ、PR diff、パスを読み、
+10 個の必須観点を調査する。証拠のある事実と未検証の仮説を分離し、
+指定フォーマットで blocker 判定まで報告する。専用スクリプトは不要で、
+探索手順と出力契約を `SKILL.md`、再現可能な小さい例を fixture に置く。
+
+## データと責務
+
+1. 利用者または CI が通常 harness か `check:pre-release` を実行する。
+2. harness が対象ファイルを列挙し、選択された rule group に渡す。
+3. 各 rule はパス、line、severity、是正先チェックリストを finding として返す。
+4. 人間は `docs/checklists/pre-release.md` から変更種別別の詳細確認へ進む。
+5. 未知の接続や運用 failure path は `/blindspot-pass <target>` で証拠付き確認をする。
+
+## エッジケース
+
+- JSX / HTML の開始タグは複数行を許容する。
+- 動的 `alt` は属性の存在を確認する。動的 `rel` は安全値を確定できないため warning とする。
+- test、fixture、生成物、依存ディレクトリは公開品質ルールの対象外にする。
+- HTML メタデータ検査は `index.html` に限定し、コンポーネント断片を公開ページと
+  誤認しない。
+- `--pre-release` はリポジトリ前提を検査せず、公開品質ルールだけを全件走査する。
+- スキルの発見に証拠がない場合は finding と断定せず仮説へ分離する。
+
+## 検証
+
+- 各公開品質ルールに正常、異常、複数行、対象外 path のテストを追加する。
+- `--pre-release` が公開品質ルールだけを実行する CLI 統合テストを追加する。
+- blindspot fixture に対する実行例が、事実と仮説を区別した指定形式になることを
+  目視確認する。
+- architecture harness、`make before-commit`、skill-audit Quick Workflow を通す。

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "bun biome check .",
     "lint:fix": "bun biome check --write .",
     "lint:text": "bun textlint ./README.md",
+    "check:pre-release": "bun scripts/architecture-harness.ts --pre-release --fail-on=error",
     "lint-staged": "lint-staged",
     "format": "bun biome format --write .",
     "format:check": "bun biome format .",

--- a/scripts/architecture-harness-types.ts
+++ b/scripts/architecture-harness-types.ts
@@ -1,0 +1,27 @@
+type Severity = 'error' | 'warning';
+type RuleGroup = 'pre-release';
+
+interface Finding {
+  rule: string;
+  severity: Severity;
+  file: string;
+  line?: number;
+  message: string;
+}
+
+interface Rule {
+  id: string;
+  description: string;
+  groups?: readonly RuleGroup[];
+  standalone?: boolean;
+  scope: (filePath: string) => boolean;
+  check: (file: { path: string; content: string }) => Finding[];
+}
+
+interface RepoCheck {
+  id: string;
+  description: string;
+  check: (root: string) => Promise<Finding[]>;
+}
+
+export type { Finding, RepoCheck, Rule, RuleGroup, Severity };

--- a/scripts/architecture-harness.test.ts
+++ b/scripts/architecture-harness.test.ts
@@ -461,6 +461,212 @@ describe('INVARIANT_NO_TYPE_ESCAPE_HATCH', () => {
   });
 });
 
+describe('公開品質ルール', () => {
+  const TSX = 'packages/frontend/src/App.tsx';
+  const HTML = 'packages/frontend/index.html';
+
+  describe('INVARIANT_NO_CLIENT_AUTH_STORAGE', () => {
+    const r = rule('INVARIANT_NO_CLIENT_AUTH_STORAGE');
+
+    it('認証情報らしい値のブラウザストレージ保存を error にする', () => {
+      const findings = r.check({
+        path: TSX,
+        content: [
+          "localStorage.setItem('accessToken', token);",
+          "sessionStorage.setItem('session', credential);",
+        ].join('\n'),
+      });
+      expect(findings).toHaveLength(2);
+      expect(findings.every((finding) => finding.severity === 'error')).toBe(
+        true
+      );
+    });
+
+    it('表示設定の保存とテストファイルは対象外にする', () => {
+      expect(
+        r.check({
+          path: TSX,
+          content: "localStorage.setItem('theme', 'dark');\n",
+        })
+      ).toHaveLength(0);
+      expect(r.scope('packages/frontend/src/App.test.tsx')).toBe(false);
+    });
+  });
+
+  describe('INVARIANT_NO_DANGEROUS_HTML', () => {
+    const r = rule('INVARIANT_NO_DANGEROUS_HTML');
+
+    it('React と DOM の危険な HTML 注入を error にする', () => {
+      const findings = r.check({
+        path: TSX,
+        content: [
+          'return <div dangerouslySetInnerHTML={{ __html: input }} />;',
+          'element.innerHTML = input;',
+        ].join('\n'),
+      });
+      expect(findings).toHaveLength(2);
+      expect(findings.every((finding) => finding.severity === 'error')).toBe(
+        true
+      );
+    });
+
+    it('通常のテキスト描画を許可する', () => {
+      expect(
+        r.check({ path: TSX, content: 'return <div>{input}</div>;\n' })
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('INVARIANT_EXTERNAL_LINK_SAFE', () => {
+    const r = rule('INVARIANT_EXTERNAL_LINK_SAFE');
+
+    it('複数行の target blank で rel が不足するリンクを error にする', () => {
+      const findings = r.check({
+        path: TSX,
+        content: [
+          '<a',
+          '  href="https://example.com"',
+          '  target="_blank"',
+          '  rel="noopener"',
+          '>',
+          '  Example',
+          '</a>',
+        ].join('\n'),
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.severity).toBe('error');
+      expect(findings[0]?.line).toBe(1);
+    });
+
+    it('noopener noreferrer の両方があれば許可する', () => {
+      expect(
+        r.check({
+          path: TSX,
+          content:
+            '<a href="https://example.com" target="_blank" rel="noreferrer noopener">Example</a>\n',
+        })
+      ).toHaveLength(0);
+    });
+
+    it('JSX 式の target blank を検出し、動的 rel は warning にする', () => {
+      const missingRel = r.check({
+        path: TSX,
+        content: "<a href={url} target={'_blank'}>Example</a>\n",
+      });
+      expect(missingRel).toHaveLength(1);
+      expect(missingRel[0]?.severity).toBe('error');
+
+      const dynamicRel = r.check({
+        path: TSX,
+        content:
+          '<a href={url} target={`_blank`} rel={externalRel}>Example</a>\n',
+      });
+      expect(dynamicRel).toHaveLength(1);
+      expect(dynamicRel[0]?.severity).toBe('warning');
+    });
+  });
+
+  describe('INVARIANT_IMAGE_ALT_REQUIRED', () => {
+    const r = rule('INVARIANT_IMAGE_ALT_REQUIRED');
+
+    it('複数行の img に alt がなければ error にする', () => {
+      const findings = r.check({
+        path: TSX,
+        content: ['<img', '  src={avatarUrl}', '/>'].join('\n'),
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.severity).toBe('error');
+    });
+
+    it('空を含む alt 属性とカスタム Image コンポーネントを許可する', () => {
+      expect(
+        r.check({
+          path: TSX,
+          content: '<img src="/divider.svg" alt="" />\n<Image src={hero} />\n',
+        })
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('INVARIANT_ICON_BUTTON_ACCESSIBLE_NAME', () => {
+    const r = rule('INVARIANT_ICON_BUTTON_ACCESSIBLE_NAME');
+
+    it('アイコンだけの button に accessible name がなければ warning にする', () => {
+      const findings = r.check({
+        path: TSX,
+        content: '<button type="button"><CloseIcon /></button>\n',
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.severity).toBe('warning');
+    });
+
+    it('aria-label または表示文字列があれば許可する', () => {
+      expect(
+        r.check({
+          path: TSX,
+          content: [
+            '<button type="button" aria-label="閉じる"><CloseIcon /></button>',
+            '<button type="button"><CloseIcon />閉じる</button>',
+          ].join('\n'),
+        })
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('INVARIANT_PUBLIC_METADATA_PRESENT', () => {
+    const r = rule('INVARIANT_PUBLIC_METADATA_PRESENT');
+    const complete = [
+      '<html lang="ja">',
+      '<head>',
+      '<meta name="description" content="説明" />',
+      '<link rel="canonical" href="https://example.com/" />',
+      '<meta property="og:title" content="Title" />',
+      '<meta property="og:description" content="Description" />',
+      '<meta property="og:url" content="https://example.com/" />',
+      '<meta property="og:image" content="https://example.com/og.png" />',
+      '<meta name="twitter:card" content="summary_large_image" />',
+      '</head>',
+      '</html>',
+    ].join('\n');
+
+    it('公開 index.html の不足メタデータを項目ごとに error にする', () => {
+      const findings = r.check({
+        path: HTML,
+        content: '<html><head><title>Page</title></head></html>\n',
+      });
+      expect(findings).toHaveLength(8);
+      expect(findings.every((finding) => finding.severity === 'error')).toBe(
+        true
+      );
+    });
+
+    it('必要なメタデータが揃えば findings を出さない', () => {
+      expect(r.check({ path: HTML, content: complete })).toHaveLength(0);
+      expect(r.scope('packages/frontend/src/fragment.html')).toBe(false);
+    });
+  });
+
+  describe('INVARIANT_NO_PRODUCTION_NOINDEX', () => {
+    const r = rule('INVARIANT_NO_PRODUCTION_NOINDEX');
+
+    it('アプリ実装に残る noindex を error にする', () => {
+      const findings = r.check({
+        path: HTML,
+        content: '<meta name="robots" content="noindex, nofollow" />\n',
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.severity).toBe('error');
+    });
+
+    it('docs と fixture は対象外にする', () => {
+      expect(r.scope('docs/noindex-example.html')).toBe(false);
+      expect(r.scope('packages/frontend/src/__fixtures__/noindex.html')).toBe(
+        false
+      );
+    });
+  });
+});
+
 describe('anti-MVP ルールの自己検出ガード', () => {
   it('ハーネス自身のソースを両ルールが誤検出しない', async () => {
     const src = await Bun.file(
@@ -550,6 +756,91 @@ describe('--skills-only モード (CLI 統合)', () => {
     const res = spawnSync(
       'bun',
       [SCRIPT, '--skills-only', `--root=${root}`, '--fail-on=warning'],
+      { encoding: 'utf8' }
+    );
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('(なし)');
+  });
+});
+
+describe('--pre-release モード (CLI 統合)', () => {
+  const SCRIPT = path.join(import.meta.dir, 'architecture-harness.ts');
+  const tempRoots: string[] = [];
+
+  afterAll(() => {
+    for (const root of tempRoots) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function makeProject(appSource: string): string {
+    const root = mkdtempSync(path.join(tmpdir(), 'pre-release-project-'));
+    tempRoots.push(root);
+    const dir = path.join(root, 'packages/frontend/src');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'App.tsx'), appSource);
+    return root;
+  }
+
+  it('公開品質ルールだけをリポジトリ前提チェックなしで実行する', () => {
+    const root = makeProject("localStorage.setItem('accessToken', token);\n");
+    const res = spawnSync(
+      'bun',
+      [SCRIPT, '--pre-release', `--root=${root}`, '--fail-on=error'],
+      { encoding: 'utf8' }
+    );
+    expect(res.status).toBe(2);
+    expect(res.stdout).toContain('INVARIANT_NO_CLIENT_AUTH_STORAGE');
+    expect(res.stdout).not.toContain('INVARIANT_SUPPLY_CHAIN_CONFIG_PRESENT');
+    expect(res.stdout).not.toContain('INVARIANT_NO_MVP_PLACEHOLDER');
+  });
+});
+
+describe('ローカル worktree の除外 (CLI 統合)', () => {
+  const SCRIPT = path.join(import.meta.dir, 'architecture-harness.ts');
+  let root = '';
+
+  afterAll(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  it('親 checkout から .claude/worktrees の複製内容を検査しない', () => {
+    root = mkdtempSync(path.join(tmpdir(), 'harness-worktrees-'));
+    const requiredFiles: Array<[string, string]> = [
+      [
+        'docs/architecture/harness.md',
+        '# Harness\n\n' +
+          'この文書はテスト用リポジトリの invariant を十分な長さで定義する正本です。'.repeat(
+            3
+          ),
+      ],
+      ['docs/adr/0000-template.md', '# ADR template\n'],
+      [
+        '.claude/skills/follow-up/SKILL.md',
+        [
+          '---',
+          'name: follow-up',
+          'description: テスト用の follow-up スキル。scope 外の発見を記録し、別の変更として管理するときに使う。',
+          '---',
+          '',
+          '# Follow-up',
+        ].join('\n'),
+      ],
+      ['bunfig.toml', 'trustedDependencies = []\n'],
+      [
+        '.claude/worktrees/agent/.github/template.md',
+        '<!-- worktree 内だけにある警告対象 -->\n',
+      ],
+    ];
+    for (const [relativePath, content] of requiredFiles) {
+      const filePath = path.join(root, relativePath);
+      mkdirSync(path.dirname(filePath), { recursive: true });
+      writeFileSync(filePath, content);
+    }
+
+    const res = spawnSync(
+      'bun',
+      [SCRIPT, `--root=${root}`, '--fail-on=warning'],
       { encoding: 'utf8' }
     );
     expect(res.status).toBe(0);

--- a/scripts/architecture-harness.test.ts
+++ b/scripts/architecture-harness.test.ts
@@ -607,6 +607,7 @@ describe('公開品質ルール', () => {
           content: [
             '<button type="button" aria-label="閉じる"><CloseIcon /></button>',
             '<button type="button"><CloseIcon />閉じる</button>',
+            '<button type="button"><CloseIcon />{label}</button>',
           ].join('\n'),
         })
       ).toHaveLength(0);

--- a/scripts/architecture-harness.ts
+++ b/scripts/architecture-harness.ts
@@ -16,33 +16,13 @@
 import { execFileSync } from 'node:child_process';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
-
-type Severity = 'error' | 'warning';
-
-interface Finding {
-  rule: string;
-  severity: Severity;
-  file: string;
-  line?: number;
-  message: string;
-}
-
-interface Rule {
-  id: string;
-  description: string;
-  // リポジトリ前提 (REPO_CHECKS) なしで単体スキャン可能なルール。
-  // --skills-only モードではこのフラグを持つルールだけが実行される。
-  standalone?: boolean;
-  // ファイル単位のチェック (false を返したら skip)
-  scope: (filePath: string) => boolean;
-  check: (file: { path: string; content: string }) => Finding[];
-}
-
-interface RepoCheck {
-  id: string;
-  description: string;
-  check: (root: string) => Promise<Finding[]>;
-}
+import type {
+  Finding,
+  RepoCheck,
+  Rule,
+  Severity,
+} from './architecture-harness-types';
+import { PRE_RELEASE_RULES } from './pre-release-rules';
 
 // --- File-level invariants ---
 
@@ -549,6 +529,7 @@ const RULES: Rule[] = [
       return findings;
     },
   },
+  ...PRE_RELEASE_RULES,
 ];
 
 // frontmatter (name/description) を持つサプライチェーン成果物 (SKILL.md / agents) の
@@ -816,7 +797,9 @@ async function walkRepo(root: string): Promise<string[]> {
     for (const entry of entries) {
       if (entry.isDirectory()) {
         if (SKIP_DIRS.has(entry.name)) continue;
-        await walk(path.join(dir, entry.name));
+        const child = path.join(dir, entry.name);
+        if (path.relative(root, child) === '.claude/worktrees') continue;
+        await walk(child);
         continue;
       }
       const rel = path.relative(root, path.join(dir, entry.name));
@@ -849,6 +832,8 @@ interface CliOptions {
   // リポジトリ外に置いたサードパーティスキル候補を /skill-audit pre-install で
   // 検査する用途 (bunfig.toml 等のリポジトリ前提を要求しない)。
   skillsOnly: boolean;
+  // 公開品質ルールだけを全件検査し、REPO_CHECKS をスキップする。
+  preRelease: boolean;
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -856,10 +841,12 @@ function parseArgs(argv: string[]): CliOptions {
     root: process.cwd(),
     staged: false,
     skillsOnly: false,
+    preRelease: false,
   };
   for (const arg of argv) {
     if (arg === '--staged') opts.staged = true;
     else if (arg === '--skills-only') opts.skillsOnly = true;
+    else if (arg === '--pre-release') opts.preRelease = true;
     else if (arg.startsWith('--root=')) opts.root = path.resolve(arg.slice(7));
     else if (arg.startsWith('--fail-on=')) {
       const v = arg.slice(10);
@@ -895,38 +882,51 @@ function formatReport(findings: Finding[]): string {
   return lines.join('\n');
 }
 
-async function main(): Promise<void> {
-  const opts = parseArgs(process.argv.slice(2));
-  const findings: Finding[] = [];
-
-  // 1) repository-level checks (--skills-only ではスキップ)
-  if (!opts.skillsOnly) {
-    for (const r of REPO_CHECKS) {
-      findings.push(...(await r.check(opts.root)));
-    }
+function selectRules(opts: CliOptions): Rule[] {
+  if (opts.skillsOnly) return RULES.filter((rule) => rule.standalone);
+  if (opts.preRelease) {
+    return RULES.filter((rule) => rule.groups?.includes('pre-release'));
   }
+  return RULES;
+}
 
-  // 2) file-level checks
-  const activeRules = opts.skillsOnly
-    ? RULES.filter((r) => r.standalone)
-    : RULES;
+async function collectRepoFindings(opts: CliOptions): Promise<Finding[]> {
+  if (opts.skillsOnly || opts.preRelease) return [];
+  const findings: Finding[] = [];
+  for (const repoCheck of REPO_CHECKS) {
+    findings.push(...(await repoCheck.check(opts.root)));
+  }
+  return findings;
+}
+
+async function collectFileFindings(opts: CliOptions): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const activeRules = selectRules(opts);
   const candidatePaths = opts.staged
     ? listStagedFiles(opts.root)
     : await walkRepo(opts.root);
-
   for (const rel of candidatePaths) {
-    const applicable = activeRules.filter((r) => r.scope(rel));
+    const applicable = activeRules.filter((rule) => rule.scope(rel));
     if (applicable.length === 0) continue;
     let content: string;
     try {
       content = await readFile(path.join(opts.root, rel), 'utf8');
     } catch {
-      continue; // 削除ファイル等
+      continue;
     }
-    for (const r of applicable) {
-      findings.push(...r.check({ path: rel, content }));
+    for (const rule of applicable) {
+      findings.push(...rule.check({ path: rel, content }));
     }
   }
+  return findings;
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const findings = [
+    ...(await collectRepoFindings(opts)),
+    ...(await collectFileFindings(opts)),
+  ];
 
   console.log(formatReport(findings));
 

--- a/scripts/pre-release-rules.ts
+++ b/scripts/pre-release-rules.ts
@@ -78,6 +78,22 @@ function openingTags(content: string): OpeningTag[] {
   return tags;
 }
 
+function hasVisibleText(content: string): boolean {
+  let cursor = 0;
+  while (cursor < content.length) {
+    const char = content[cursor];
+    if (/\s/.test(char)) {
+      cursor++;
+      continue;
+    }
+    if (char !== '<') return true;
+    const end = findTagEnd(content, cursor + 1);
+    if (end === -1) return true;
+    cursor = end + 1;
+  }
+  return false;
+}
+
 function hasAttribute(tag: string, name: string): boolean {
   return new RegExp(`\\b${name}\\s*=`, 'i').test(tag);
 }
@@ -255,12 +271,7 @@ const PRE_RELEASE_RULES: Rule[] = [
         .filter((tag) => {
           const close = content.toLowerCase().indexOf('</button>', tag.end);
           if (close === -1) return false;
-          const inner = content
-            .slice(tag.end, close)
-            .replace(/<[^>]+>/g, '')
-            .replace(/\{[^}]*\}/g, '')
-            .trim();
-          return inner.length === 0;
+          return !hasVisibleText(content.slice(tag.end, close));
         })
         .map((tag) =>
           finding(

--- a/scripts/pre-release-rules.ts
+++ b/scripts/pre-release-rules.ts
@@ -1,0 +1,325 @@
+import type { Finding, Rule, Severity } from './architecture-harness-types';
+
+const PRE_RELEASE_GROUP = ['pre-release'] as const;
+const CHECKLIST = 'docs/checklists/pre-release.md';
+const WEB_SOURCE = /\.(html|tsx|jsx)$/;
+const SCRIPT_SOURCE = /\.(ts|tsx|js|jsx)$/;
+
+interface OpeningTag {
+  name: string;
+  source: string;
+  start: number;
+  end: number;
+  line: number;
+}
+
+function isTestArtifact(filePath: string): boolean {
+  return (
+    /\.(test|spec)\.[^.]+$/.test(filePath) ||
+    /(^|\/)(__fixtures__|__mocks__|__tests__|tests?)\//.test(filePath)
+  );
+}
+
+function isAppFile(filePath: string, extension: RegExp): boolean {
+  return (
+    (filePath.startsWith('packages/') || filePath.startsWith('src/')) &&
+    extension.test(filePath) &&
+    !isTestArtifact(filePath)
+  );
+}
+
+function lineAt(content: string, offset: number): number {
+  return content.slice(0, offset).split('\n').length;
+}
+
+function nextQuote(quote: string, char: string, previous: string): string {
+  if (!quote) return char === '"' || char === "'" || char === '`' ? char : '';
+  return char === quote && previous !== '\\' ? '' : quote;
+}
+
+function nextBraceDepth(depth: number, char: string): number {
+  if (char === '{') return depth + 1;
+  if (char === '}') return Math.max(0, depth - 1);
+  return depth;
+}
+
+function findTagEnd(content: string, start: number): number {
+  let quote = '';
+  let braceDepth = 0;
+  for (let index = start; index < content.length; index++) {
+    const char = content[index];
+    const updatedQuote = nextQuote(quote, char, content[index - 1] ?? '');
+    if (updatedQuote !== quote) {
+      quote = updatedQuote;
+      continue;
+    }
+    if (quote) continue;
+    braceDepth = nextBraceDepth(braceDepth, char);
+    if (char === '>' && braceDepth === 0) return index;
+  }
+  return -1;
+}
+
+function openingTags(content: string): OpeningTag[] {
+  const tags: OpeningTag[] = [];
+  const startPattern = /<([A-Za-z][\w.:-]*)\b/g;
+  for (const match of content.matchAll(startPattern)) {
+    const start = match.index;
+    const end = findTagEnd(content, start + match[0].length);
+    if (end === -1) continue;
+    tags.push({
+      name: match[1],
+      source: content.slice(start, end + 1),
+      start,
+      end: end + 1,
+      line: lineAt(content, start),
+    });
+  }
+  return tags;
+}
+
+function hasAttribute(tag: string, name: string): boolean {
+  return new RegExp(`\\b${name}\\s*=`, 'i').test(tag);
+}
+
+function quotedAttribute(tag: string, name: string): string | null {
+  const match = new RegExp(`\\b${name}\\s*=\\s*(["'])(.*?)\\1`, 'is').exec(tag);
+  return match?.[2] ?? null;
+}
+
+function finding(
+  rule: string,
+  severity: Severity,
+  file: string,
+  line: number,
+  message: string
+): Finding {
+  return {
+    rule,
+    severity,
+    file,
+    line,
+    message: `${message}。確認先: ${CHECKLIST}`,
+  };
+}
+
+function regexFindings(
+  rule: string,
+  filePath: string,
+  content: string,
+  pattern: RegExp,
+  message: string
+): Finding[] {
+  return Array.from(content.matchAll(pattern), (match) =>
+    finding(rule, 'error', filePath, lineAt(content, match.index), message)
+  );
+}
+
+function externalLinkFinding(
+  filePath: string,
+  tag: OpeningTag
+): Finding | null {
+  if (!hasAttribute(tag.source, 'rel')) {
+    return finding(
+      'INVARIANT_EXTERNAL_LINK_SAFE',
+      'error',
+      filePath,
+      tag.line,
+      'target="_blank" には rel="noopener noreferrer" を指定する'
+    );
+  }
+  const rel = quotedAttribute(tag.source, 'rel');
+  if (rel === null) {
+    return finding(
+      'INVARIANT_EXTERNAL_LINK_SAFE',
+      'warning',
+      filePath,
+      tag.line,
+      '動的 rel が noopener noreferrer の両方を常に返すことを確認する'
+    );
+  }
+  const values = new Set(rel.toLowerCase().split(/\s+/));
+  if (values.has('noopener') && values.has('noreferrer')) return null;
+  return finding(
+    'INVARIANT_EXTERNAL_LINK_SAFE',
+    'error',
+    filePath,
+    tag.line,
+    'target="_blank" には rel="noopener noreferrer" を指定する'
+  );
+}
+
+const PRE_RELEASE_RULES: Rule[] = [
+  {
+    id: 'INVARIANT_NO_CLIENT_AUTH_STORAGE',
+    description:
+      'localStorage / sessionStorage に認証情報らしいキーや値を保存しない',
+    groups: PRE_RELEASE_GROUP,
+    scope: (filePath) => isAppFile(filePath, SCRIPT_SOURCE),
+    check: ({ path: filePath, content }) => {
+      const setItem =
+        /\b(?:window\s*\.\s*)?(?:localStorage|sessionStorage)\s*\.\s*setItem\s*\(([\s\S]*?)\)/gi;
+      const property =
+        /\b(?:window\s*\.\s*)?(?:localStorage|sessionStorage)\s*(?:\.|\[\s*["'`])(?:[\w-]*(?:token|auth|session|credential)[\w-]*)/gi;
+      const sensitive =
+        /\b(?:accessToken|refreshToken|idToken|token|auth|session|credential)s?\b/i;
+      const findings = Array.from(content.matchAll(setItem))
+        .filter((match) => sensitive.test(match[1]))
+        .map((match) =>
+          finding(
+            'INVARIANT_NO_CLIENT_AUTH_STORAGE',
+            'error',
+            filePath,
+            lineAt(content, match.index),
+            '認証情報を JavaScript から読めるブラウザストレージへ保存しない'
+          )
+        );
+      findings.push(
+        ...regexFindings(
+          'INVARIANT_NO_CLIENT_AUTH_STORAGE',
+          filePath,
+          content,
+          property,
+          '認証情報を JavaScript から読めるブラウザストレージへ保存しない'
+        )
+      );
+      return findings;
+    },
+  },
+  {
+    id: 'INVARIANT_NO_DANGEROUS_HTML',
+    description:
+      'React の危険な HTML 注入と DOM innerHTML 代入をアプリ実装に残さない',
+    groups: PRE_RELEASE_GROUP,
+    scope: (filePath) => isAppFile(filePath, SCRIPT_SOURCE),
+    check: ({ path: filePath, content }) =>
+      regexFindings(
+        'INVARIANT_NO_DANGEROUS_HTML',
+        filePath,
+        content,
+        /\bdangerouslySetInnerHTML\b|\.\s*innerHTML\s*=/g,
+        '未検証の HTML 注入経路を使わず、React のテキストエスケープを維持する'
+      ),
+  },
+  {
+    id: 'INVARIANT_EXTERNAL_LINK_SAFE',
+    description: 'target blank のリンクに noopener noreferrer の両方を指定する',
+    groups: PRE_RELEASE_GROUP,
+    scope: (filePath) => isAppFile(filePath, WEB_SOURCE),
+    check: ({ path: filePath, content }) =>
+      openingTags(content)
+        .filter((tag) =>
+          /\btarget\s*=\s*(?:["']_blank["']|\{\s*["'`]_blank["'`]\s*\})/i.test(
+            tag.source
+          )
+        )
+        .map((tag) => externalLinkFinding(filePath, tag))
+        .filter((result): result is Finding => result !== null),
+  },
+  {
+    id: 'INVARIANT_IMAGE_ALT_REQUIRED',
+    description: 'ネイティブ img 要素に alt 属性を必須にする',
+    groups: PRE_RELEASE_GROUP,
+    scope: (filePath) => isAppFile(filePath, WEB_SOURCE),
+    check: ({ path: filePath, content }) =>
+      openingTags(content)
+        .filter(
+          (tag) =>
+            tag.name.toLowerCase() === 'img' && !hasAttribute(tag.source, 'alt')
+        )
+        .map((tag) =>
+          finding(
+            'INVARIANT_IMAGE_ALT_REQUIRED',
+            'error',
+            filePath,
+            tag.line,
+            'img に内容を表す alt、または装飾画像を示す空 alt を指定する'
+          )
+        ),
+  },
+  {
+    id: 'INVARIANT_ICON_BUTTON_ACCESSIBLE_NAME',
+    description:
+      'アイコンだけの button に accessible name があることを確認する',
+    groups: PRE_RELEASE_GROUP,
+    scope: (filePath) => isAppFile(filePath, WEB_SOURCE),
+    check: ({ path: filePath, content }) =>
+      openingTags(content)
+        .filter((tag) => tag.name.toLowerCase() === 'button')
+        .filter(
+          (tag) =>
+            !['aria-label', 'aria-labelledby', 'title'].some((attribute) =>
+              hasAttribute(tag.source, attribute)
+            )
+        )
+        .filter((tag) => {
+          const close = content.toLowerCase().indexOf('</button>', tag.end);
+          if (close === -1) return false;
+          const inner = content
+            .slice(tag.end, close)
+            .replace(/<[^>]+>/g, '')
+            .replace(/\{[^}]*\}/g, '')
+            .trim();
+          return inner.length === 0;
+        })
+        .map((tag) =>
+          finding(
+            'INVARIANT_ICON_BUTTON_ACCESSIBLE_NAME',
+            'warning',
+            filePath,
+            tag.line,
+            'アイコンだけの button に aria-label などの accessible name を指定する'
+          )
+        ),
+  },
+  {
+    id: 'INVARIANT_PUBLIC_METADATA_PRESENT',
+    description:
+      '公開 index.html に言語、description、canonical、OGP、Twitter Card を必須にする',
+    groups: PRE_RELEASE_GROUP,
+    scope: (filePath) =>
+      isAppFile(filePath, /\.html$/) && /(^|\/)index\.html$/.test(filePath),
+    check: ({ path: filePath, content }) => {
+      const requirements: Array<[string, RegExp]> = [
+        ['html lang', /<html\b[^>]*\blang\s*=/i],
+        ['meta description', /<meta\b[^>]*\bname=["']description["']/i],
+        [
+          'canonical URL',
+          /<link\b[^>]*\brel=["'][^"']*\bcanonical\b[^"']*["']/i,
+        ],
+        ['og:title', /<meta\b[^>]*\bproperty=["']og:title["']/i],
+        ['og:description', /<meta\b[^>]*\bproperty=["']og:description["']/i],
+        ['og:url', /<meta\b[^>]*\bproperty=["']og:url["']/i],
+        ['og:image', /<meta\b[^>]*\bproperty=["']og:image["']/i],
+        ['twitter:card', /<meta\b[^>]*\bname=["']twitter:card["']/i],
+      ];
+      return requirements
+        .filter(([, pattern]) => !pattern.test(content))
+        .map(([label]) =>
+          finding(
+            'INVARIANT_PUBLIC_METADATA_PRESENT',
+            'error',
+            filePath,
+            1,
+            `公開 index.html に ${label} を指定する`
+          )
+        );
+    },
+  },
+  {
+    id: 'INVARIANT_NO_PRODUCTION_NOINDEX',
+    description: '本番向けの HTML / JSX / TSX に noindex を残さない',
+    groups: PRE_RELEASE_GROUP,
+    scope: (filePath) => isAppFile(filePath, WEB_SOURCE),
+    check: ({ path: filePath, content }) =>
+      regexFindings(
+        'INVARIANT_NO_PRODUCTION_NOINDEX',
+        filePath,
+        content,
+        /\bnoindex\b/gi,
+        '本番向けページの noindex を外す。検索非公開が要件なら ADR に残す'
+      ),
+  },
+];
+
+export { PRE_RELEASE_RULES };


### PR DESCRIPTION
## この PR で動くようになること

テンプレート利用プロジェクトで、公開前の高シグナルな危険パターンを `bun run check:pre-release` と通常の architecture harness から検出できるようになります。設計・Issue・PR・実装経路に残る未知は `/blindspot-pass` で、コードを変更せず証拠付きレビューできます。

## 変更内容

- architecture harness に `pre-release` rule group と `--pre-release` モードを追加
- 認証情報の browser storage 保存、危険な HTML 注入、安全でない external link、画像 alt 不足、icon-only button、公開 metadata 不足、`noindex` を検査
- セキュリティ、アクセシビリティ、SEO / OGP、運用、公開前の 5 checklist を追加
- PR template、GitHub Actions、README、`init-project` を公開品質ゲートへ接続
- review-only の `/blindspot-pass` と fixture / 実行例を追加
- 設計文書と ADR-0006 に自動検査と人間レビューの責務境界を記録
- CodeQL の sanitizer 判定を避ける構造走査で icon-only button を検査

## 設計判断

独立 scanner を増やさず、既存 harness の rule group として実装しました。通常ゲートと専用 command が同じ判定ロジックを使うため、検査結果の差分を作りません。意味解析が必要な認可、cache、復旧、監視は checklist とレビューが担当します。

## 検証

クリーン worktree の commit `7497b69` で確認しました。

- `bun scripts/architecture-harness.ts --fail-on=warning`
- `make before-commit`
- `bun test scripts/` — 68 pass
- `bun run check:pre-release`
- skill-audit Quick Workflow と目視レビュー
- `git diff --check`
- GitHub Actions / CodeQL / GitGuardian — Green

## Known follow-ups

- F-N6NEVS: textlint の全 docs 対象化と immutable ADR の整合方針を別 PR で決める (`severity: high`)

Closes https://github.com/susumutomita/typescript-template/issues/112
Closes https://github.com/susumutomita/typescript-template/issues/120
